### PR TITLE
Bump cerebro to 0.0.2

### DIFF
--- a/charts/cerebro/Chart.yaml
+++ b/charts/cerebro/Chart.yaml
@@ -1,5 +1,5 @@
 name: cerebro
-version: 0.0.1
+version: 0.0.2
 appVersion: 0.9.4
 apiVersion: v2
 description: A Helm chart for Cerebro - a web admin tool that replaces Kopf.


### PR DESCRIPTION
As part of the documentation update, bumping Chart for cerebro to version 0.0.2