### PR TITLE
Add capability to configure affinity from values

### DIFF
--- a/charts/elasticsearch-umbrella/Chart.yaml
+++ b/charts/elasticsearch-umbrella/Chart.yaml
@@ -24,14 +24,14 @@ appVersion: 6.6.2
 # A list of the chart requirements 
 dependencies:
   - name: elasticsearch-statefulset
-    version: "0.3.0"
+    version: "0.4.0"
     alias: master
   - name: elasticsearch-statefulset
-    version: "0.3.0"
+    version: "0.4.0"
     alias: data
   - name: elasticsearch-statefulset
-    version: "0.3.0"
+    version: "0.4.0"
     alias: index
   - name: elasticsearch-deployment
-    version: "0.3.0"
+    version: "0.4.0"
     alias: client

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/Chart.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/templates/deployment.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/templates/deployment.yaml
@@ -181,18 +181,39 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if or (eq .Values.antiAffinity "hard") (eq .Values.antiAffinity "soft") .Values.nodeAffinity }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       affinity:
+      {{- end }}
+      {{- if eq .Values.antiAffinity "hard" }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: "app.kubernetes.io/name"
+                operator: In
+                values:
+                - {{ include "statefulset.fullname" . }}
+            topologyKey: {{ .Values.antiAffinityTopologyKey }}
+      {{- else if eq .Values.antiAffinity "soft" }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: "app.kubernetes.io/name"
-                      operator: In
-                      values:
-                        - {{ include "deployment.fullname" . }}
-                topologyKey: kubernetes.io/hostname
-              weight: 100
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: {{ .Values.antiAffinityTopologyKey }}
+              labelSelector:
+                matchExpressions:
+                - key: "app.kubernetes.io/name"
+                  operator: In
+                  values:
+                  - {{ include "statefulset.fullname" . }}
+      {{- end }}
+      {{- with .Values.nodeAffinity }}
+        nodeAffinity:
+{{ toYaml . | indent 10 }}
+      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/values.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/values.yaml
@@ -140,6 +140,22 @@ tolerations: []
 #     operator: Equal
 #     value: es-master
 
+# This is the PriorityClass settings as defined in
+# https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+priorityClassName: ""
+
+# By default this will make sure two pods don't end up on the same node
+# Changing this to a region would allow you to spread pods across regions
+antiAffinityTopologyKey: "kubernetes.io/hostname"
+
+# Hard means that by default pods will only be scheduled if there are enough nodes for them
+# and that they will never end up on the same node. Setting this to soft will do this "best effort"
+antiAffinity: "soft"
+
+# This is the node affinity settings as defined in
+# https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
+nodeAffinity: {}
+
 rbac:
   # -- Whether RBAC rules should be created (Role and Rolebinding)
   create: false

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/Chart.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/statefulset.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/statefulset.yaml
@@ -232,18 +232,39 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if or (eq .Values.antiAffinity "hard") (eq .Values.antiAffinity "soft") .Values.nodeAffinity }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       affinity:
+      {{- end }}
+      {{- if eq .Values.antiAffinity "hard" }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: "app.kubernetes.io/name"
+                operator: In
+                values:
+                - {{ include "statefulset.fullname" . }}
+            topologyKey: {{ .Values.antiAffinityTopologyKey }}
+      {{- else if eq .Values.antiAffinity "soft" }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: "app.kubernetes.io/name"
-                      operator: In
-                      values:
-                        - {{ include "statefulset.fullname" . }}
-                topologyKey: kubernetes.io/hostname
-              weight: 100
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: {{ .Values.antiAffinityTopologyKey }}
+              labelSelector:
+                matchExpressions:
+                - key: "app.kubernetes.io/name"
+                  operator: In
+                  values:
+                  - {{ include "statefulset.fullname" . }}
+      {{- end }}
+      {{- with .Values.nodeAffinity }}
+        nodeAffinity:
+{{ toYaml . | indent 10 }}
+      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/values.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/values.yaml
@@ -156,6 +156,22 @@ tolerations: []
 #     operator: Equal
 #     value: es-master
 
+# This is the PriorityClass settings as defined in
+# https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+priorityClassName: ""
+
+# By default this will make sure two pods don't end up on the same node
+# Changing this to a region would allow you to spread pods across regions
+antiAffinityTopologyKey: "kubernetes.io/hostname"
+
+# Hard means that by default pods will only be scheduled if there are enough nodes for them
+# and that they will never end up on the same node. Setting this to soft will do this "best effort"
+antiAffinity: "soft"
+
+# This is the node affinity settings as defined in
+# https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
+nodeAffinity: {}
+
 rbac:
   # -- Whether RBAC rules should be created (Role and Rolebinding)
   create: false


### PR DESCRIPTION
Upgrade the elasticsearch-umbrella helm chart to add the capability to set up the affinity from the values.