### PR TITLE
SRC-1319 Adapt helm chart to run with both Elastic 6 and 7. 

### DIFF
--- a/charts/elasticsearch-umbrella/Chart.yaml
+++ b/charts/elasticsearch-umbrella/Chart.yaml
@@ -15,23 +15,23 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 6.6.2
+appVersion: 6.8.23
 # A list of the chart requirements 
 dependencies:
   - name: elasticsearch-statefulset
-    version: "0.6.0"
+    version: "0.7.0"
     alias: master
   - name: elasticsearch-statefulset
-    version: "0.6.0"
+    version: "0.7.0"
     alias: data
   - name: elasticsearch-statefulset
-    version: "0.6.0"
+    version: "0.7.0"
     alias: index
   - name: elasticsearch-deployment
-    version: "0.6.0"
+    version: "0.7.0"
     alias: client

--- a/charts/elasticsearch-umbrella/README.md
+++ b/charts/elasticsearch-umbrella/README.md
@@ -1,146 +1,232 @@
-# Elasticsearch-umbrella
+# elasticsearch-umbrella
 
-This Helm chart is Empathy's own Helm chart (based on the official [Elasticsearch Helm chart](https://github.com/elastic/helm-charts/tree/master/elasticsearch)) to deploy an Elasticsearch 6.6.2 with a custom Dockerfile habilitating unlimited memory lock (`ulimit -l unlimited`). Additionally, [justwatchcom Elasticsearh Exporter](https://github.com/justwatchcom/elasticsearch_exporter) is deployed as a sidecar container to expose Prometheus metrics in port `9114`.
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.8.23](https://img.shields.io/badge/AppVersion-6.8.23-informational?style=flat-square)
 
-**N.B.** Please note this Helm chart is an umbrella chart for Empathy's [Elasticsearch-master Helm chart](../elasticsearch-master) and [Elasticsearch-data Helm chart](../elasticsearch-data)
-
-## Requirements
-
-- Kubernetes >= 1.14
-- [Helm](https://helm.sh/) 3
-- Minimum cluster requirements include the following to run this chart with default settings.
-	- Three Kubernetes nodes to respect the `topologyKey: "kubernetes.io/hostname"` antiaffinity.
-	- 3GB of RAM for the JVM heap.
-	- 1 vCPU available for resource limits.
-	- 200Gi of capacity for each persistent volume (elasticsearch-data Helm chart).
-
-## Installing
-
-To install the chart with the release name `elasticsearch-umbrella` and default values, run:
-
-```bash
-$ helm repo add empathy-public https://empathyco.github.io/helm-charts
-$ helm install elasticsearch-umbrella empathy-public/elasticsearch-umbrella
-```
-
-## Uninstalling the Chart
-
-To uninstall/delete the `elasticsearch-umbrella` deployment:
-
-```bash
-$ helm delete elasticsearch-umbrella
-```
-
-The command removes all the Kubernetes components associated with the chart and deletes the release.
-
-## Usage notes
-
-- The chart just deploys the Empathy's [elasticsearch-master](../elasticsearch-master) and [elastocsearch-data](../elasticsearch-data) as an umbrella Helm chart, to simplify Elasticsearch 6.6.2 deployment. Please refer to the corresponding subcharts for detailed documentation.
-- Please make sure to use the same values for `elasticsearch-data.elastic_config."cluster.name"` and `elasticsearch-master.elastic_config."cluster.name"` so that both charts belong to the same Elasticsearch cluster.
-- Please also note that `elasticsearch-data.elastic_config."discovery.zen.ping.unicast.hosts"` and `elasticsearch-master.elastic_config."discovery.zen.ping.unicast.hosts"` should have the same value which depends on your release name as `<RELEASE_NAME>-elasticsearch-master-discovery`.
+A Helm chart for Kubernetes
 
 ## Requirements
 
 | Repository | Name | Version |
 |------------|------|---------|
-|  | elasticsearch-data | 0.1.0 |
-|  | elasticsearch-master | 0.1.0 |
+|  | client(elasticsearch-deployment) | 0.7.0 |
+|  | master(elasticsearch-statefulset) | 0.7.0 |
+|  | data(elasticsearch-statefulset) | 0.7.0 |
+|  | index(elasticsearch-statefulset) | 0.7.0 |
 
-## Configuration
+## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| elasticsearch-data.busybox.image | string | `"busybox:1.31"` | Image for busybox initContainers (sysctlInitContainer in official Elasticsearch Helm chart) |
-| elasticsearch-data.elastic_config | object | `{"ES_JAVA_OPTS":"-Xms2048m -Xmx2048m","bootstrap.memory_lock":"true","logger.org.elasticsearch.discovery.gce":"TRACE","network.bind_host":"0.0.0.0","node.attr.type":"search","node.data":"true","node.ingest":"true","node.master":"false","node.ml":"false","transport.tcp.compress":"true"}` | Elasticsearch configuration added in a configMap and passed to the Elasticsearch pods as Env. Vars. |
-| elasticsearch-data.elastic_config."bootstrap.memory_lock" | string | `"true"` | Elasticsearch enable memory lock to avoid swapping |
-| elasticsearch-data.elastic_config."logger.org.elasticsearch.discovery.gce" | string | `"TRACE"` | Elasticsearch GCE discovery log level |
-| elasticsearch-data.elastic_config."network.bind_host" | string | `"0.0.0.0"` | Elasticsearch network.bind_host, network address(es) to which the node should bind in order to listen for incoming connections. |
-| elasticsearch-data.elastic_config."node.attr.type" | string | `"search"` | Elasticsearch node attribute type |
-| elasticsearch-data.elastic_config."node.data" | string | `"true"` | Elasticsearch data node role |
-| elasticsearch-data.elastic_config."node.ingest" | string | `"true"` | Elasticsearch ingest node role |
-| elasticsearch-data.elastic_config."node.master" | string | `"false"` | Elasticsearch master node role |
-| elasticsearch-data.elastic_config."node.ml" | string | `"false"` | Elasticsearch ml node role |
-| elasticsearch-data.elastic_config."transport.tcp.compress" | string | `"true"` | Elasticsearch enable compression between nodes |
-| elasticsearch-data.elastic_config.ES_JAVA_OPTS | string | `"-Xms2048m -Xmx2048m"` | Elasticsearch JVM options |
-| elasticsearch-data.fullnameOverride | string | `""` | Overrides the clusterName and nodeGroup when used in the naming of resources. This should only be used when using a single nodeGroup, otherwise you will have name conflicts |
-| elasticsearch-data.image.pullPolicy | string | `"IfNotPresent"` | The Kubernetes imagePullPolicy value |
-| elasticsearch-data.image.repository | string | `"empathyco/elasticsearch"` | Docker repository for Elasticsearch image |
-| elasticsearch-data.image.tag | string | `"6.6.2-memlock"` | Overrides the image tag whose default is the chart appVersion. |
-| elasticsearch-data.imagePullSecrets | list | `[]` | Configuration for imagePullSecrets so that you can use a private registry for your image |
-| elasticsearch-data.ingress.annotations | object | `{}` | Annotations for Kubernetes Ingress |
-| elasticsearch-data.ingress.enabled | bool | `false` | Enable Kubernetes Ingress to expose Elasticsearch pods |
-| elasticsearch-data.ingress.hosts | list | `[]` | Host and path for Kubernetes Ingress. See values.yaml for an example |
-| elasticsearch-data.ingress.tls | list | `[]` | TLS secret for exposing Elasticsearch with https. See values.yaml for an example |
-| elasticsearch-data.nameOverride | string | `""` | Overrides the clusterName when used in the naming of resources |
-| elasticsearch-data.nodeSelector | object | `{}` | Configurable nodeSelector so that you can target specific nodes for your Elasticsearch cluster |
-| elasticsearch-data.podAnnotations | object | `{}` | Configurable annotations applied to all Elasticsearch pods |
-| elasticsearch-data.podSecurityContext | object | `{}` | Allows you to set the securityContext for the pod |
-| elasticsearch-data.podSecurityPolicy.create | bool | `false` | Create a podSecurityPolicy with minimal permissions to run this Helm chart. Be sure to also set rbac.create to true, otherwise Role and RoleBinding won't be created. |
-| elasticsearch-data.podSecurityPolicy.name | string | `""` | The name of the podSecurityPolicy to use. If not set and create is true, a name is generated using the fullname template |
-| elasticsearch-data.podSecurityPolicy.spec | object | `{}` | Spec to apply to the podSecurityPolicy. See values.yaml for an example |
-| elasticsearch-data.prometheus.annotations | object | `{"app":"prometheus-operator","release":"prometheus"}` | Annotations to include in the ServiceMonitor |
-| elasticsearch-data.prometheus.enabled | bool | `false` | Deploy a ServiceMonitor for Prometheus scrapping |
-| elasticsearch-data.prometheus.exporter.image | string | `"justwatch/elasticsearch_exporter:1.1.0"` | Exporter image to deploy as a sidecar container |
-| elasticsearch-data.rbac.create | bool | `false` | Whether RBAC rules should be created (Role and Rolebinding) |
-| elasticsearch-data.replicaCount | int | `3` | Kubernetes replica count for the StatefulSet (i.e. how many pods) |
-| elasticsearch-data.resources.limits.cpu | string | `"1000m"` | CPU limits for the StatefulSet |
-| elasticsearch-data.resources.limits.memory | string | `"3Gi"` | Memory limits for the StatefulSet |
-| elasticsearch-data.resources.requests.cpu | string | `"1000m"` | CPU requests for the StatefulSet |
-| elasticsearch-data.resources.requests.memory | string | `"3Gi"` | Memory requests for the StatefulSet |
-| elasticsearch-data.securityContext | object | `{"capabilities":{"add":["IPC_LOCK","SYS_RESOURCE"]}}` | Allows you to set the securityContext for the container |
-| elasticsearch-data.service.port | int | `9200` | Kubernetes service port, used by Ingress to expose Elasticsearch pods |
-| elasticsearch-data.service.type | string | `"ClusterIP"` | Kubernetes service type |
-| elasticsearch-data.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
-| elasticsearch-data.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
-| elasticsearch-data.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
-| elasticsearch-data.tolerations | list | `[]` | Configurable tolerations |
-| elasticsearch-data.volume.annotations | object | `{}` | Annotations for statefulSet volumes |
-| elasticsearch-data.volume.storage | string | `"200Gi"` | Storage resources for statefulSet volumes |
-| elasticsearch-data.volume.storage_class | string | `"standard"` | Storage class for statefulSet volumes |
-| elasticsearch-master.busybox.image | string | `"busybox:1.31"` | Image for busybox initContainers (sysctlInitContainer in official Elasticsearch Helm chart) |
-| elasticsearch-master.elastic_config | object | `{"ES_JAVA_OPTS":"-Xms2048m -Xmx2048m","bootstrap.memory_lock":"true","discovery.zen.minimum_master_nodes":"1","network.bind_host":"0.0.0.0","node.data":"false","node.ingest":"false","node.master":"true","node.ml":"false","transport.tcp.compress":"true"}` | Elasticsearch configuration added in a configMap and passed to the Elasticsearch pods as Env. Vars. |
-| elasticsearch-master.elastic_config."bootstrap.memory_lock" | string | `"true"` | Elasticsearch enable memory lock to avoid swapping |
-| elasticsearch-master.elastic_config."discovery.zen.minimum_master_nodes" | string | `"1"` | Minimum number of master eligible nodes that need to join a newly elected master in order for an election to complete and for the elected node to accept its mastership. |
-| elasticsearch-master.elastic_config."network.bind_host" | string | `"0.0.0.0"` | Elasticsearch network.bind_host, network address(es) to which the node should bind in order to listen for incoming connections. |
-| elasticsearch-master.elastic_config."node.data" | string | `"false"` | Elasticsearch data node role |
-| elasticsearch-master.elastic_config."node.ingest" | string | `"false"` | Elasticsearch ingest node role |
-| elasticsearch-master.elastic_config."node.master" | string | `"true"` | Elasticsearch master node role |
-| elasticsearch-master.elastic_config."node.ml" | string | `"false"` | Elasticsearch ml node role |
-| elasticsearch-master.elastic_config."transport.tcp.compress" | string | `"true"` | Elasticsearch enable compression between nodes |
-| elasticsearch-master.elastic_config.ES_JAVA_OPTS | string | `"-Xms2048m -Xmx2048m"` | Elasticsearch JVM options |
-| elasticsearch-master.fullnameOverride | string | `""` | Overrides the clusterName and nodeGroup when used in the naming of resources. This should only be used when using a single nodeGroup, otherwise you will have name conflicts |
-| elasticsearch-master.image.pullPolicy | string | `"IfNotPresent"` | The Kubernetes imagePullPolicy value |
-| elasticsearch-master.image.repository | string | `"empathyco/elasticsearch"` | Docker repository for Elasticsearch image |
-| elasticsearch-master.image.tag | string | `"6.6.2-memlock"` | Overrides the image tag whose default is the chart appVersion. |
-| elasticsearch-master.imagePullSecrets | list | `[]` | Configuration for imagePullSecrets so that you can use a private registry for your image |
-| elasticsearch-master.ingress.annotations | object | `{}` | Annotations for Kubernetes Ingress |
-| elasticsearch-master.ingress.enabled | bool | `false` | Enable Kubernetes Ingress to expose Elasticsearch pods |
-| elasticsearch-master.ingress.hosts | list | `[]` | Host and path for Kubernetes Ingress. See values.yaml for an example |
-| elasticsearch-master.ingress.tls | list | `[]` | TLS secret for exposing Elasticsearch with https. See values.yaml for an example |
-| elasticsearch-master.nameOverride | string | `""` | Overrides the clusterName when used in the naming of resources |
-| elasticsearch-master.nodeSelector | object | `{}` | Configurable nodeSelector so that you can target specific nodes for your Elasticsearch cluster |
-| elasticsearch-master.podAnnotations | object | `{}` | Configurable annotations applied to all Elasticsearch pods |
-| elasticsearch-master.podSecurityContext | object | `{}` | Allows you to set the securityContext for the pod |
-| elasticsearch-master.podSecurityPolicy.create | bool | `false` | Create a podSecurityPolicy with minimal permissions to run this Helm chart. Be sure to also set rbac.create to true, otherwise Role and RoleBinding won't be created. |
-| elasticsearch-master.podSecurityPolicy.name | string | `""` | The name of the podSecurityPolicy to use. If not set and create is true, a name is generated using the fullname template |
-| elasticsearch-master.podSecurityPolicy.spec | object | `{}` | Spec to apply to the podSecurityPolicy. See values.yaml for an example |
-| elasticsearch-master.prometheus.annotations | object | `{"app":"prometheus-operator","release":"prometheus"}` | Annotations to include in the ServiceMonitor |
-| elasticsearch-master.prometheus.enabled | bool | `false` | Deploy a ServiceMonitor for Prometheus scrapping |
-| elasticsearch-master.prometheus.exporter.image | string | `"justwatch/elasticsearch_exporter:1.1.0"` | Exporter image to deploy as a sidecar container |
-| elasticsearch-master.rbac.create | bool | `false` | Whether RBAC rules should be created (Role and Rolebinding) |
-| elasticsearch-master.replicaCount | int | `3` | Kubernetes replica count for the Deployment (i.e. how many pods) |
-| elasticsearch-master.resources.limits.cpu | string | `"1000m"` | CPU limits for the Deployment |
-| elasticsearch-master.resources.limits.memory | string | `"3Gi"` | Memory limits for the Deployment |
-| elasticsearch-master.resources.requests.cpu | string | `"1000m"` | CPU requests for the Deployment |
-| elasticsearch-master.resources.requests.memory | string | `"3Gi"` | Memory requests for the Deployment |
-| elasticsearch-master.securityContext | object | `{"capabilities":{"add":["IPC_LOCK","SYS_RESOURCE"]}}` | Allows you to set the securityContext for the container |
-| elasticsearch-master.service.port | int | `9200` | Kubernetes service port, used by Ingress to expose Elasticsearch pods |
-| elasticsearch-master.service.type | string | `"ClusterIP"` | Kubernetes service type |
-| elasticsearch-master.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
-| elasticsearch-master.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
-| elasticsearch-master.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
-| elasticsearch-master.tolerations | list | `[]` | Configurable tolerations |
-| global.elastic_config."cluster.name" | string | `"test-es"` | Elasticsearch cluster.name and should be unique per cluster in the namespace. Note that it should be the same as elasticsearch-data.elastic_config."cluster.name" so both subcharts belong to the same cluster. |
+| client.busybox.image | string | `"busybox:1.31"` | Image for busybox initContainers (sysctlInitContainer in official Elasticsearch Helm chart) |
+| client.elastic_config | object | `{"ES_JAVA_OPTS":"-Xms2048m -Xmx2048m","bootstrap.memory_lock":"true","logger.org.elasticsearch.discovery.gce":"TRACE","network.bind_host":"0.0.0.0","node.data":"false","node.master":"false","node.ml":"false","transport.tcp.compress":"true"}` | Elasticsearch configuration added in a configMap and passed to the Elasticsearch pods as Env. Vars. |
+| client.elastic_config."bootstrap.memory_lock" | string | `"true"` | Elasticsearch enable memory lock to avoid swapping |
+| client.elastic_config."logger.org.elasticsearch.discovery.gce" | string | `"TRACE"` | Elasticsearch GCE discovery log level |
+| client.elastic_config."network.bind_host" | string | `"0.0.0.0"` | Elasticsearch network.bind_host, network address(es) to which the node should bind in order to listen for incoming connections. |
+| client.elastic_config."node.data" | string | `"false"` | Elasticsearch data node role |
+| client.elastic_config."node.master" | string | `"false"` | Elasticsearch master node role |
+| client.elastic_config."node.ml" | string | `"false"` | Elasticsearch ml node role |
+| client.elastic_config."transport.tcp.compress" | string | `"true"` | Elasticsearch enable compression between nodes |
+| client.elastic_config.ES_JAVA_OPTS | string | `"-Xms2048m -Xmx2048m"` | Elasticsearch JVM options |
+| client.enabled | bool | `true` | Enabling or disabling client nodes |
+| client.fullnameOverride | string | `""` | Overrides the clusterName and nodeGroup when used in the naming of resources. This should only be used when using a single nodeGroup, otherwise you will have name conflicts |
+| client.image.pullPolicy | string | `"IfNotPresent"` | The Kubernetes imagePullPolicy value |
+| client.image.repository | string | `"empathyco/elasticsearch"` | Docker repository for Elasticsearch image |
+| client.image.tag | string | `"6.8.23-memlock"` | Overrides the image tag whose default is the chart appVersion. |
+| client.imagePullSecrets | list | `[]` | Configuration for imagePullSecrets so that you can use a private registry for your image |
+| client.ingress.annotations | object | `{}` | Annotations for Kubernetes Ingress |
+| client.ingress.className | string | `""` | IngressClass name for ingress exposition |
+| client.ingress.enabled | bool | `false` | Enable Kubernetes Ingress to expose Elasticsearch pods |
+| client.ingress.hosts | list | `[]` | Host and path for Kubernetes Ingress. See values.yaml for an example |
+| client.ingress.tls | list | `[]` | TLS secret for exposing Elasticsearch with https. See values.yaml for an example |
+| client.nameOverride | string | `""` | Overrides the clusterName when used in the naming of resources |
+| client.nodeSelector | object | `{}` | Configurable nodeSelector so that you can target specific nodes for your Elasticsearch cluster |
+| client.podAnnotations | object | `{}` | Configurable annotations applied to all Elasticsearch pods |
+| client.podSecurityContext | object | `{}` | Allows you to set the securityContext for the pod |
+| client.podSecurityPolicy.create | bool | `false` | Create a podSecurityPolicy with minimal permissions to run this Helm chart. Be sure to also set rbac.create to true, otherwise Role and RoleBinding won't be created. |
+| client.podSecurityPolicy.name | string | `""` | The name of the podSecurityPolicy to use. If not set and create is true, a name is generated using the fullname template |
+| client.podSecurityPolicy.spec | object | `{}` | Spec to apply to the podSecurityPolicy. See values.yaml for an example |
+| client.prometheus.annotations | object | `{"app":"prometheus-operator","release":"prometheus"}` | Annotations to include in the ServiceMonitor |
+| client.prometheus.enabled | bool | `false` | Deploy a ServiceMonitor for Prometheus scrapping |
+| client.prometheus.exporter.image | string | `"justwatch/elasticsearch_exporter:1.1.0"` | Exporter image to deploy as a sidecar container |
+| client.prometheus.resources.limits.cpu | string | `"100m"` |  |
+| client.prometheus.resources.limits.memory | string | `"128Mi"` |  |
+| client.prometheus.resources.requests.cpu | string | `"100m"` |  |
+| client.prometheus.resources.requests.memory | string | `"128Mi"` |  |
+| client.rbac.create | bool | `false` | Whether RBAC rules should be created (Role and Rolebinding) |
+| client.replicaCount | int | `3` | Kubernetes replica count for the Deployment (i.e. how many pods) |
+| client.resources.limits.cpu | string | `"1000m"` | CPU limits for the StatefulSet |
+| client.resources.limits.memory | string | `"3Gi"` | Memory limits for the StatefulSet |
+| client.resources.requests.cpu | string | `"1000m"` | CPU requests for the StatefulSet |
+| client.resources.requests.memory | string | `"3Gi"` | Memory requests for the StatefulSet |
+| client.securityContext | object | `{"capabilities":{"add":["IPC_LOCK","SYS_RESOURCE"]}}` | Allows you to set the securityContext for the container |
+| client.service.port | int | `9200` | Kubernetes service port, used by Ingress to expose Elasticsearch pods |
+| client.service.type | string | `"ClusterIP"` | Kubernetes service type |
+| client.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| client.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| client.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| client.tolerations | list | `[]` | Configurable tolerations |
+| data.busybox.image | string | `"busybox:1.31"` | Image for busybox initContainers (sysctlInitContainer in official Elasticsearch Helm chart) |
+| data.elastic_config | object | `{"ES_JAVA_OPTS":"-Xms2048m -Xmx2048m","bootstrap.memory_lock":"true","logger.org.elasticsearch.discovery.gce":"TRACE","network.bind_host":"0.0.0.0","node.attr.type":"search","node.data":"true","node.ingest":"true","node.master":"false","node.ml":"false","transport.tcp.compress":"true"}` | Elasticsearch configuration added in a configMap and passed to the Elasticsearch pods as Env. Vars. |
+| data.elastic_config."bootstrap.memory_lock" | string | `"true"` | Elasticsearch enable memory lock to avoid swapping |
+| data.elastic_config."logger.org.elasticsearch.discovery.gce" | string | `"TRACE"` | Elasticsearch GCE discovery log level |
+| data.elastic_config."network.bind_host" | string | `"0.0.0.0"` | Elasticsearch network.bind_host, network address(es) to which the node should bind in order to listen for incoming connections. |
+| data.elastic_config."node.attr.type" | string | `"search"` | Elasticsearch node attribute type |
+| data.elastic_config."node.data" | string | `"true"` | Elasticsearch data node role |
+| data.elastic_config."node.ingest" | string | `"true"` | Elasticsearch ingest node role |
+| data.elastic_config."node.master" | string | `"false"` | Elasticsearch master node role |
+| data.elastic_config."node.ml" | string | `"false"` | Elasticsearch ml node role |
+| data.elastic_config."transport.tcp.compress" | string | `"true"` | Elasticsearch enable compression between nodes |
+| data.elastic_config.ES_JAVA_OPTS | string | `"-Xms2048m -Xmx2048m"` | Elasticsearch JVM options |
+| data.enabled | bool | `true` | Enabling or disabling data nodes |
+| data.fullnameOverride | string | `""` | Overrides the clusterName and nodeGroup when used in the naming of resources. This should only be used when using a single nodeGroup, otherwise you will have name conflicts |
+| data.image.pullPolicy | string | `"IfNotPresent"` | The Kubernetes imagePullPolicy value |
+| data.image.repository | string | `"empathyco/elasticsearch"` | Docker repository for Elasticsearch image |
+| data.image.tag | string | `"6.8.23-memlock"` | Overrides the image tag whose default is the chart appVersion. |
+| data.imagePullSecrets | list | `[]` | Configuration for imagePullSecrets so that you can use a private registry for your image |
+| data.ingress.annotations | object | `{}` | Annotations for Kubernetes Ingress |
+| data.ingress.className | string | `""` | IngressClass name for ingress exposition |
+| data.ingress.enabled | bool | `false` | Enable Kubernetes Ingress to expose Elasticsearch pods |
+| data.ingress.hosts | list | `[]` | Host and path for Kubernetes Ingress. See values.yaml for an example |
+| data.ingress.tls | list | `[]` | TLS secret for exposing Elasticsearch with https. See values.yaml for an example |
+| data.isMaster | bool | `false` | This property indicates its the master |
+| data.nameOverride | string | `""` | Overrides the clusterName when used in the naming of resources |
+| data.nodeSelector | object | `{}` | Configurable nodeSelector so that you can target specific nodes for your Elasticsearch cluster |
+| data.podAnnotations | object | `{}` | Configurable annotations applied to all Elasticsearch pods |
+| data.podSecurityContext | object | `{}` | Allows you to set the securityContext for the pod |
+| data.podSecurityPolicy.create | bool | `false` | Create a podSecurityPolicy with minimal permissions to run this Helm chart. Be sure to also set rbac.create to true, otherwise Role and RoleBinding won't be created. |
+| data.podSecurityPolicy.name | string | `""` | The name of the podSecurityPolicy to use. If not set and create is true, a name is generated using the fullname template |
+| data.podSecurityPolicy.spec | object | `{}` | Spec to apply to the podSecurityPolicy. See values.yaml for an example |
+| data.prometheus.annotations | object | `{"app":"prometheus-operator","release":"prometheus"}` | Annotations to include in the ServiceMonitor |
+| data.prometheus.enabled | bool | `false` | Deploy a ServiceMonitor for Prometheus scrapping |
+| data.prometheus.exporter.image | string | `"justwatch/elasticsearch_exporter:1.1.0"` | Exporter image to deploy as a sidecar container |
+| data.prometheus.resources.limits.cpu | string | `"100m"` |  |
+| data.prometheus.resources.limits.memory | string | `"128Mi"` |  |
+| data.prometheus.resources.requests.cpu | string | `"100m"` |  |
+| data.prometheus.resources.requests.memory | string | `"128Mi"` |  |
+| data.rbac.create | bool | `false` | Whether RBAC rules should be created (Role and Rolebinding) |
+| data.replicaCount | int | `3` | Kubernetes replica count for the StatefulSet (i.e. how many pods) |
+| data.resources.limits.cpu | string | `"1000m"` | CPU limits for the StatefulSet |
+| data.resources.limits.memory | string | `"3Gi"` | Memory limits for the StatefulSet |
+| data.resources.requests.cpu | string | `"1000m"` | CPU requests for the StatefulSet |
+| data.resources.requests.memory | string | `"3Gi"` | Memory requests for the StatefulSet |
+| data.securityContext | object | `{"capabilities":{"add":["IPC_LOCK","SYS_RESOURCE"]}}` | Allows you to set the securityContext for the container |
+| data.service.port | int | `9200` | Kubernetes service port, used by Ingress to expose Elasticsearch pods |
+| data.service.type | string | `"ClusterIP"` | Kubernetes service type |
+| data.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| data.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| data.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| data.tolerations | list | `[]` | Configurable tolerations |
+| data.volume.annotations | object | `{}` | Annotations for statefulSet volumes |
+| data.volume.storage | string | `"200Gi"` | Storage resources for statefulSet volumes |
+| data.volume.storage_class | string | `"standard"` | Storage class for statefulSet volumes |
+| global.elastic_config."cluster.name" | string | `"es"` | Elasticsearch cluster.name and should be unique per cluster in the namespace. Note that it should be the same as elasticsearch-data.elastic_config."cluster.name" so both subcharts belong to the same cluster. |
+| global.masterFullname | string | `"es-master"` | Fullname of the master, necessary to connect |
+| index.busybox.image | string | `"busybox:1.31"` | Image for busybox initContainers (sysctlInitContainer in official Elasticsearch Helm chart) |
+| index.elastic_config | object | `{"ES_JAVA_OPTS":"-Xms2048m -Xmx2048m","bootstrap.memory_lock":"true","logger.org.elasticsearch.discovery.gce":"TRACE","network.bind_host":"0.0.0.0","node.attr.type":"index","node.data":"true","node.ingest":"true","node.master":"false","node.ml":"false","transport.tcp.compress":"true"}` | Elasticsearch configuration added in a configMap and passed to the Elasticsearch pods as Env. Vars. |
+| index.elastic_config."bootstrap.memory_lock" | string | `"true"` | Elasticsearch enable memory lock to avoid swapping |
+| index.elastic_config."logger.org.elasticsearch.discovery.gce" | string | `"TRACE"` | Elasticsearch GCE discovery log level |
+| index.elastic_config."network.bind_host" | string | `"0.0.0.0"` | Elasticsearch network.bind_host, network address(es) to which the node should bind in order to listen for incoming connections. |
+| index.elastic_config."node.attr.type" | string | `"index"` | Elasticsearch node attribute type |
+| index.elastic_config."node.data" | string | `"true"` | Elasticsearch data node role |
+| index.elastic_config."node.ingest" | string | `"true"` | Elasticsearch ingest node role |
+| index.elastic_config."node.master" | string | `"false"` | Elasticsearch master node role |
+| index.elastic_config."node.ml" | string | `"false"` | Elasticsearch ml node role |
+| index.elastic_config."transport.tcp.compress" | string | `"true"` | Elasticsearch enable compression between nodes |
+| index.elastic_config.ES_JAVA_OPTS | string | `"-Xms2048m -Xmx2048m"` | Elasticsearch JVM options |
+| index.enabled | bool | `true` | Enabling or disabling index nodes |
+| index.fullnameOverride | string | `""` | Overrides the clusterName and nodeGroup when used in the naming of resources. This should only be used when using a single nodeGroup, otherwise you will have name conflicts |
+| index.image.pullPolicy | string | `"IfNotPresent"` | The Kubernetes imagePullPolicy value |
+| index.image.repository | string | `"empathyco/elasticsearch"` | Docker repository for Elasticsearch image |
+| index.image.tag | string | `"6.8.23-memlock"` | Overrides the image tag whose default is the chart appVersion. |
+| index.imagePullSecrets | list | `[]` | Configuration for imagePullSecrets so that you can use a private registry for your image |
+| index.ingress.annotations | object | `{}` | Annotations for Kubernetes Ingress |
+| index.ingress.className | string | `""` | IngressClass name for ingress exposition |
+| index.ingress.enabled | bool | `false` | Enable Kubernetes Ingress to expose Elasticsearch pods |
+| index.ingress.hosts | list | `[]` | Host and path for Kubernetes Ingress. See values.yaml for an example |
+| index.ingress.tls | list | `[]` | TLS secret for exposing Elasticsearch with https. See values.yaml for an example |
+| index.isMaster | bool | `false` | This property indicates its the master |
+| index.nameOverride | string | `""` | Overrides the clusterName when used in the naming of resources |
+| index.nodeSelector | object | `{}` | Configurable nodeSelector so that you can target specific nodes for your Elasticsearch cluster |
+| index.podAnnotations | object | `{}` | Configurable annotations applied to all Elasticsearch pods |
+| index.podSecurityContext | object | `{}` | Allows you to set the securityContext for the pod |
+| index.podSecurityPolicy.create | bool | `false` | Create a podSecurityPolicy with minimal permissions to run this Helm chart. Be sure to also set rbac.create to true, otherwise Role and RoleBinding won't be created. |
+| index.podSecurityPolicy.name | string | `""` | The name of the podSecurityPolicy to use. If not set and create is true, a name is generated using the fullname template |
+| index.podSecurityPolicy.spec | object | `{}` | Spec to apply to the podSecurityPolicy. See values.yaml for an example |
+| index.prometheus.annotations | object | `{"app":"prometheus-operator","release":"prometheus"}` | Annotations to include in the ServiceMonitor |
+| index.prometheus.enabled | bool | `false` | Deploy a ServiceMonitor for Prometheus scrapping |
+| index.prometheus.exporter.image | string | `"justwatch/elasticsearch_exporter:1.1.0"` | Exporter image to deploy as a sidecar container |
+| index.prometheus.resources.limits.cpu | string | `"100m"` |  |
+| index.prometheus.resources.limits.memory | string | `"128Mi"` |  |
+| index.prometheus.resources.requests.cpu | string | `"100m"` |  |
+| index.prometheus.resources.requests.memory | string | `"128Mi"` |  |
+| index.rbac.create | bool | `false` | Whether RBAC rules should be created (Role and Rolebinding) |
+| index.replicaCount | int | `1` | Kubernetes replica count for the StatefulSet (i.e. how many pods) |
+| index.resources.limits.cpu | string | `"1000m"` | CPU limits for the StatefulSet |
+| index.resources.limits.memory | string | `"3Gi"` | Memory limits for the StatefulSet |
+| index.resources.requests.cpu | string | `"1000m"` | CPU requests for the StatefulSet |
+| index.resources.requests.memory | string | `"3Gi"` | Memory requests for the StatefulSet |
+| index.securityContext | object | `{"capabilities":{"add":["IPC_LOCK","SYS_RESOURCE"]}}` | Allows you to set the securityContext for the container |
+| index.service.port | int | `9200` | Kubernetes service port, used by Ingress to expose Elasticsearch pods |
+| index.service.type | string | `"ClusterIP"` | Kubernetes service type |
+| index.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| index.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| index.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| index.tolerations | list | `[]` | Configurable tolerations |
+| index.volume.annotations | object | `{}` | Annotations for statefulSet volumes |
+| index.volume.storage | string | `"200Gi"` | Storage resources for statefulSet volumes |
+| index.volume.storage_class | string | `"standard"` | Storage class for statefulSet volumes |
+| master.busybox.image | string | `"busybox:1.31"` | Image for busybox initContainers (sysctlInitContainer in official Elasticsearch Helm chart) |
+| master.elastic_config | object | `{"ES_JAVA_OPTS":"-Xms2048m -Xmx2048m","bootstrap.memory_lock":"true","discovery.zen.minimum_master_nodes":"1","network.bind_host":"0.0.0.0","node.data":"false","node.ingest":"false","node.master":"true","node.ml":"false","transport.tcp.compress":"true"}` | Elasticsearch configuration added in a configMap and passed to the Elasticsearch pods as Env. Vars. |
+| master.elastic_config."bootstrap.memory_lock" | string | `"true"` | Elasticsearch enable memory lock to avoid swapping |
+| master.elastic_config."discovery.zen.minimum_master_nodes" | string | `"1"` | Minimum number of master eligible nodes that need to join a newly elected master in order for an election to complete and for the elected node to accept its mastership. |
+| master.elastic_config."network.bind_host" | string | `"0.0.0.0"` | Elasticsearch network.bind_host, network address(es) to which the node should bind in order to listen for incoming connections. |
+| master.elastic_config."node.data" | string | `"false"` | Elasticsearch data node role |
+| master.elastic_config."node.ingest" | string | `"false"` | Elasticsearch ingest node role |
+| master.elastic_config."node.master" | string | `"true"` | Elasticsearch master node role |
+| master.elastic_config."node.ml" | string | `"false"` | Elasticsearch ml node role |
+| master.elastic_config."transport.tcp.compress" | string | `"true"` | Elasticsearch enable compression between nodes |
+| master.elastic_config.ES_JAVA_OPTS | string | `"-Xms2048m -Xmx2048m"` | Elasticsearch JVM options |
+| master.enabled | bool | `true` | Enabling or disabling master nodes |
+| master.fullnameOverride | string | `""` | Overrides the clusterName and nodeGroup when used in the naming of resources. This should only be used when using a single nodeGroup, otherwise you will have name conflicts |
+| master.image.pullPolicy | string | `"IfNotPresent"` | The Kubernetes imagePullPolicy value |
+| master.image.repository | string | `"empathyco/elasticsearch"` | Docker repository for Elasticsearch image |
+| master.image.tag | string | `"6.8.23-memlock"` | Overrides the image tag whose default is the chart appVersion. |
+| master.imagePullSecrets | list | `[]` | Configuration for imagePullSecrets so that you can use a private registry for your image |
+| master.ingress.annotations | object | `{}` | Annotations for Kubernetes Ingress |
+| master.ingress.className | string | `""` | IngressClass name for ingress exposition |
+| master.ingress.enabled | bool | `false` | Enable Kubernetes Ingress to expose Elasticsearch pods |
+| master.ingress.hosts | list | `[]` | Host and path for Kubernetes Ingress. See values.yaml for an example |
+| master.ingress.tls | list | `[]` | TLS secret for exposing Elasticsearch with https. See values.yaml for an example |
+| master.isMaster | bool | `true` | This property indicates its the master |
+| master.nameOverride | string | `""` | Overrides the clusterName when used in the naming of resources |
+| master.nodeSelector | object | `{}` | Configurable nodeSelector so that you can target specific nodes for your Elasticsearch cluster |
+| master.podAnnotations | object | `{}` | Configurable annotations applied to all Elasticsearch pods |
+| master.podSecurityContext | object | `{}` | Allows you to set the securityContext for the pod |
+| master.podSecurityPolicy.create | bool | `false` | Create a podSecurityPolicy with minimal permissions to run this Helm chart. Be sure to also set rbac.create to true, otherwise Role and RoleBinding won't be created. |
+| master.podSecurityPolicy.name | string | `""` | The name of the podSecurityPolicy to use. If not set and create is true, a name is generated using the fullname template |
+| master.podSecurityPolicy.spec | object | `{}` | Spec to apply to the podSecurityPolicy. See values.yaml for an example |
+| master.prometheus.annotations | object | `{"app":"prometheus-operator","release":"prometheus"}` | Annotations to include in the ServiceMonitor |
+| master.prometheus.dashboard.enabled | bool | `true` |  |
+| master.prometheus.dashboard.namespace | string | `"monitoring"` |  |
+| master.prometheus.enabled | bool | `false` | Deploy a ServiceMonitor for Prometheus scrapping |
+| master.prometheus.exporter.image | string | `"justwatch/elasticsearch_exporter:1.1.0"` | Exporter image to deploy as a sidecar container |
+| master.prometheus.resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Deploy a Grafana Dashboard |
+| master.rbac.create | bool | `false` | Whether RBAC rules should be created (Role and Rolebinding) |
+| master.replicaCount | int | `3` | Kubernetes replica count for the Statefulset (i.e. how many pods) |
+| master.resources.limits.cpu | string | `"1000m"` | CPU limits for the Deployment |
+| master.resources.limits.memory | string | `"3Gi"` | Memory limits for the Deployment |
+| master.resources.requests.cpu | string | `"1000m"` | CPU requests for the Deployment |
+| master.resources.requests.memory | string | `"3Gi"` | Memory requests for the Deployment |
+| master.securityContext | object | `{"capabilities":{"add":["IPC_LOCK","SYS_RESOURCE"]}}` | Allows you to set the securityContext for the container |
+| master.service.port | int | `9200` | Kubernetes service port, used by Ingress to expose Elasticsearch pods |
+| master.service.type | string | `"ClusterIP"` | Kubernetes service type |
+| master.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| master.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| master.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| master.tolerations | list | `[]` | Configurable tolerations |
+| master.volume.annotations | object | `{}` | Annotations for statefulSet volumes |
+| master.volume.storage | string | `"5Gi"` | Storage resources for statefulSet volumes |
+| master.volume.storage_class | string | `"standard"` | Storage class for statefulSet volumes |
 
 ----------------------------------------------
 Autogenerated from chart metadata using [helm-docs v1.5.0](https://github.com/norwoodj/helm-docs/releases/v1.5.0)

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/Chart.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 6.6.2
+appVersion: 6.8.23

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/templates/configmap.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/templates/configmap.yaml
@@ -6,7 +6,7 @@ data:
   discovery.zen.ping.unicast.hosts: {{ .Values.global.masterFullname }}-discovery
 kind: ConfigMap
 metadata:
-  annotations:
+  annotations: {}
   labels:
     {{- include "deployment.labels" . | nindent 4 }}
   name: {{ include "deployment.fullname" . }}

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/values.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/values.yaml
@@ -10,11 +10,11 @@ replicaCount: 3
 
 image:
   # -- Docker repository for Elasticsearch image
-  repository: eu.gcr.io/carrefour-fr-750c11a47fecaeff/empathy-search/elasticsearch-gcp
+  repository: harbor.internal.shared.empathy.co/empathyco/elasticsearch
   # -- The Kubernetes imagePullPolicy value
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.
-  tag: "6.6.2-memlock1"
+  tag: "6.8.23-memlock"
   
 # -- Configuration for imagePullSecrets so that you can use a private registry for your image
 imagePullSecrets: []

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/values.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 3
 
 image:
   # -- Docker repository for Elasticsearch image
-  repository: harbor.internal.shared.empathy.co/empathyco/elasticsearch
+  repository: "empathyco/elasticsearch"
   # -- The Kubernetes imagePullPolicy value
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/Chart.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 6.6.2
+appVersion: 6.8.23

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/README.md
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/README.md
@@ -1,49 +1,15 @@
-# Elasticsearch-data Helm Chart
+# elasticsearch-statefulset
 
-This Helm chart is Empathy's own Helm chart (based on the official [Elasticsearch Helm chart](https://github.com/elastic/helm-charts/tree/master/elasticsearch)) to deploy data and ingest Elasticsearch 6.6.2 nodes with a custom Dockerfile habilitating unlimited memory lock (`ulimit -l unlimited`). Additionally, [justwatchcom Elasticsearh Exporter](https://github.com/justwatchcom/elasticsearch_exporter) is deployed as a sidecar container to expose Prometheus metrics in port `9114`.
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.8.23](https://img.shields.io/badge/AppVersion-6.8.23-informational?style=flat-square)
 
-**N.B.** Please note this Helm chart is specifically tailored to deploy Elasticsearch nodes with the data and ingest roles. For a fully functional Elasticsearch deployment you will have to also deploy Elasticsearch master nodes which can be achieved with Empathy's [Elasticsearch-master Helm chart](../elasticsearch-master).
-
-## Requirements
-
-- Kubernetes >= 1.14
-- [Helm](https://helm.sh/) 3
-- Minimum cluster requirements include the following to run this chart with default settings.
-	- Three Kubernetes nodes to respect the `topologyKey: "kubernetes.io/hostname"` antiaffinity.
-	- 3GB of RAM for the JVM heap.
-	- 1 vCPU available for resource limits.
-	- 200Gi of capacity for each persistent volume.
-
-## Installing
-
-To install the chart with the release name `my-release` and default values, run:
-
-```bash
-$ helm repo add empathy-public https://empathyco.github.io/helm-charts
-$ helm install --name my-release empathy-public/elasticsearch-data
-```
-
-## Uninstalling the Chart
-
-To uninstall/delete the `my-release` deployment:
-
-```bash
-$ helm delete my-release
-```
-
-The command removes all the Kubernetes components associated with the chart and deletes the release.
-
-## Usage notes
-
-- The chart deploys a StatefulSet and by default will do an automated rolling update of your cluster. It does this by waiting for the cluster health to become green after each instance is updated. If you prefer to update manually you can set OnDelete updateStrategy.
-- It is important to verify that the JVM heap size in `elastic_config.ES_JAVA_OPTS` and to set the CPU/Memory resources to something suitable for your cluster.
-- To simplify chart and maintenance each set of node groups is deployed as a separate Helm release, this chart referring to nodes with the data and ingest roles, while the Empathy's [Elasticsearch-master Helm chart](../elasticsearch-master) handles master nodes. This is basically the idea expressed in the official Elasticsearch Helm chart [multi example](https://github.com/elastic/helm-charts/tree/master/elasticsearch/examples/multi/). Without doing this it isn't possible to resize persistent volumes in a StatefulSet. By setting it up this way it makes it possible to add more nodes with a new storage size then drain the old ones. It also solves the problem of allowing the user to determine which node groups to update first when doing upgrades or changes.
-- Although based on the official [Elasticsearch Helm Chart](https://github.com/elastic/helm-charts/tree/master/elasticsearch) and the multi example mentioned in the previous point, this chart is much more opinionated that the official Helm chart. It is only thought to deploy nodes with the data and index roles, not masters, with the [justwatchcom Elasticsearh Exporter](https://github.com/justwatchcom/elasticsearch_exporter) and a custom docker image of Elastic 6.6.2 with an unlimited memory lock. Please make sure this chart fits your needs before using it.
+A Helm chart for Kubernetes
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| antiAffinity | string | `"soft"` |  |
+| antiAffinityTopologyKey | string | `"kubernetes.io/hostname"` |  |
 | busybox.image | string | `"busybox:1.31"` | Image for busybox initContainers (sysctlInitContainer in official Elasticsearch Helm chart) |
 | elastic_config | object | `{"ES_JAVA_OPTS":"-Xms2048m -Xmx2048m","bootstrap.memory_lock":"true","logger.org.elasticsearch.discovery.gce":"TRACE","network.bind_host":"0.0.0.0","node.attr.type":"search","node.data":"true","node.ingest":"true","node.master":"false","node.ml":"false","transport.tcp.compress":"true"}` | Elasticsearch configuration added in a configMap and passed to the Elasticsearch pods as Env. Vars. |
 | elastic_config."bootstrap.memory_lock" | string | `"true"` | Elasticsearch enable memory lock to avoid swapping |
@@ -59,8 +25,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | enabled | bool | `true` | Enabling or disabling master nodes |
 | fullnameOverride | string | `""` | Overrides the clusterName and nodeGroup when used in the naming of resources. This should only be used when using a single nodeGroup, otherwise you will have name conflicts |
 | image.pullPolicy | string | `"IfNotPresent"` | The Kubernetes imagePullPolicy value |
-| image.repository | string | `"eu.gcr.io/carrefour-fr-750c11a47fecaeff/empathy-search/elasticsearch-gcp"` | Docker repository for Elasticsearch image |
-| image.tag | string | `"6.6.2-memlock1"` | Overrides the image tag whose default is the chart appVersion. |
+| image.repository | string | `"empathyco/elasticsearch"` | Docker repository for Elasticsearch image |
+| image.tag | string | `"6.8.23-memlock"` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Configuration for imagePullSecrets so that you can use a private registry for your image |
 | ingress.annotations | object | `{}` | Annotations for Kubernetes Ingress |
 | ingress.className | string | `""` | IngressClass name for ingress exposition |
@@ -69,12 +35,15 @@ The command removes all the Kubernetes components associated with the chart and 
 | ingress.tls | list | `[]` | TLS secret for exposing Elasticsearch with https. See values.yaml for an example |
 | isMaster | bool | `true` | This property indicates its the master |
 | nameOverride | string | `""` | Overrides the clusterName when used in the naming of resources |
+| nodeAffinity | object | `{}` |  |
 | nodeSelector | object | `{}` | Configurable nodeSelector so that you can target specific nodes for your Elasticsearch cluster |
 | podAnnotations | object | `{}` | Configurable annotations applied to all Elasticsearch pods |
+| podManagementPolicy | string | `""` | The default is to deploy all pods serially. By setting this to parallel all pods are started at the same time when bootstrapping the cluster |
 | podSecurityContext | object | `{}` | Allows you to set the securityContext for the pod |
 | podSecurityPolicy.create | bool | `false` | Create a podSecurityPolicy with minimal permissions to run this Helm chart. Be sure to also set rbac.create to true, otherwise Role and RoleBinding won't be created. |
 | podSecurityPolicy.name | string | `""` | The name of the podSecurityPolicy to use. If not set and create is true, a name is generated using the fullname template |
 | podSecurityPolicy.spec | object | `{}` | Spec to apply to the podSecurityPolicy. See values.yaml for an example |
+| priorityClassName | string | `""` |  |
 | prometheus.annotations | object | `{"app":"prometheus-operator","release":"prometheus"}` | Annotations to include in the ServiceMonitor |
 | prometheus.dashboard | object | `{"enabled":true,"namespace":"monitoring"}` | Deploy a Grafana Dashboard |
 | prometheus.enabled | bool | `true` | Deploy a ServiceMonitor for Prometheus scrapping |

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/configmap.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/configmap.yaml
@@ -3,10 +3,22 @@ apiVersion: v1
 data:
   {{- toYaml .Values.global.elastic_config | nindent 2 }}
   {{- toYaml .Values.elastic_config | nindent 2 }}
+  {{- if semverCompare ">=7.0.0-0" .Values.image.tag }}
+  {{- if .Values.isMaster }}
+  cluster.initial_master_nodes: {{ $replicas := int (toString (.Values.replicaCount)) }}
+  {{- $uname := .Values.global.masterFullname }}
+   {{- range $i, $e := untilStep 0 $replicas 1 -}}
+  {{ $uname }}-{{ $i }},
+  {{- end }}
+  {{- end }}
+  discovery.seed_hosts: {{ .Values.global.masterFullname }}-discovery
+  {{- else }}
+  # -- Elasticsearch Zen discovery static unicast hosts
   discovery.zen.ping.unicast.hosts: {{ .Values.global.masterFullname }}-discovery
+  {{- end }}
 kind: ConfigMap
 metadata:
-  annotations:
+  annotations: {}
   labels:
     {{- include "statefulset.labels" . | nindent 4 }}
   name: {{ include "statefulset.fullname" . }}

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/service.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/service.yaml
@@ -37,7 +37,14 @@ metadata:
     {{- include "statefulset.labels" . | nindent 4 }}
 spec:
   clusterIP: None
+  {{- if semverCompare ">=7.0.0-0" .Values.image.tag }}
+  publishNotReadyAddresses: true
+  {{- end }}
   ports:
+    - port: 9200
+      targetPort: http
+      protocol: TCP
+      name: http
     - port: 9300
       targetPort: transport
       protocol: TCP

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/statefulset.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/statefulset.yaml
@@ -7,6 +7,9 @@ metadata:
     {{- include "statefulset.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- with .Values.podManagementPolicy }}
+  podManagementPolicy: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "statefulset.selectorLabels" . | nindent 6 }}

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/values.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/values.yaml
@@ -12,11 +12,11 @@ replicaCount: 3
 
 image:
   # -- Docker repository for Elasticsearch image
-  repository: eu.gcr.io/carrefour-fr-750c11a47fecaeff/empathy-search/elasticsearch-gcp
+  repository: harbor.internal.shared.empathy.co/empathyco/elasticsearch
   # -- The Kubernetes imagePullPolicy value
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.
-  tag: "6.6.2-memlock1"
+  tag: "6.8.23-memlock"
   
 # -- Configuration for imagePullSecrets so that you can use a private registry for your image
 imagePullSecrets: []
@@ -85,6 +85,10 @@ prometheus:
   exporter:
   # -- Exporter image to deploy as a sidecar container
     image: justwatch/elasticsearch_exporter:1.1.0
+
+# -- The default is to deploy all pods serially. By setting this to parallel all pods are started at
+# the same time when bootstrapping the cluster
+podManagementPolicy: ""
 
 # -- Configurable annotations applied to all Elasticsearch pods
 podAnnotations: {}

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/values.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/values.yaml
@@ -12,7 +12,7 @@ replicaCount: 3
 
 image:
   # -- Docker repository for Elasticsearch image
-  repository: harbor.internal.shared.empathy.co/empathyco/elasticsearch
+  repository: "empathyco/elasticsearch"
   # -- The Kubernetes imagePullPolicy value
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.

--- a/charts/elasticsearch-umbrella/values.yaml
+++ b/charts/elasticsearch-umbrella/values.yaml
@@ -15,11 +15,11 @@ master:
 
   image:
     # -- Docker repository for Elasticsearch image
-    repository: "empathyco/elasticsearch"
+    repository: harbor.internal.shared.empathy.co/empathyco/elasticsearch
     # -- The Kubernetes imagePullPolicy value
     pullPolicy: IfNotPresent
     # -- Overrides the image tag whose default is the chart appVersion.
-    tag: "6.6.2-memlock"
+    tag: "6.8.23-memlock"
 
   # -- Configuration for imagePullSecrets so that you can use a private registry for your image
   imagePullSecrets: []
@@ -205,11 +205,11 @@ data:
 
   image:
     # -- Docker repository for Elasticsearch image
-    repository: "empathyco/elasticsearch"
+    repository: harbor.internal.shared.empathy.co/empathyco/elasticsearch
     # -- The Kubernetes imagePullPolicy value
     pullPolicy: IfNotPresent
     # -- Overrides the image tag whose default is the chart appVersion.
-    tag: "6.6.2-memlock"
+    tag: "6.8.23-memlock"
     
   # -- Configuration for imagePullSecrets so that you can use a private registry for your image
   imagePullSecrets: []
@@ -393,11 +393,11 @@ index:
 
   image:
     # -- Docker repository for Elasticsearch image
-    repository: "empathyco/elasticsearch"
+    repository: harbor.internal.shared.empathy.co/empathyco/elasticsearch
     # -- The Kubernetes imagePullPolicy value
     pullPolicy: IfNotPresent
     # -- Overrides the image tag whose default is the chart appVersion.
-    tag: "6.6.2-memlock"
+    tag: "6.8.23-memlock"
     
   # -- Configuration for imagePullSecrets so that you can use a private registry for your image
   imagePullSecrets: []

--- a/charts/elasticsearch-umbrella/values.yaml
+++ b/charts/elasticsearch-umbrella/values.yaml
@@ -15,7 +15,7 @@ master:
 
   image:
     # -- Docker repository for Elasticsearch image
-    repository: harbor.internal.shared.empathy.co/empathyco/elasticsearch
+    repository: "empathyco/elasticsearch"
     # -- The Kubernetes imagePullPolicy value
     pullPolicy: IfNotPresent
     # -- Overrides the image tag whose default is the chart appVersion.
@@ -205,7 +205,7 @@ data:
 
   image:
     # -- Docker repository for Elasticsearch image
-    repository: harbor.internal.shared.empathy.co/empathyco/elasticsearch
+    repository: "empathyco/elasticsearch"
     # -- The Kubernetes imagePullPolicy value
     pullPolicy: IfNotPresent
     # -- Overrides the image tag whose default is the chart appVersion.
@@ -393,7 +393,7 @@ index:
 
   image:
     # -- Docker repository for Elasticsearch image
-    repository: harbor.internal.shared.empathy.co/empathyco/elasticsearch
+    repository: "empathyco/elasticsearch"
     # -- The Kubernetes imagePullPolicy value
     pullPolicy: IfNotPresent
     # -- Overrides the image tag whose default is the chart appVersion.
@@ -583,7 +583,7 @@ client:
     # -- The Kubernetes imagePullPolicy value
     pullPolicy: IfNotPresent
     # -- Overrides the image tag whose default is the chart appVersion.
-    tag: "6.6.2-memlock"
+    tag: "6.8.23-memlock"
     
   # -- Configuration for imagePullSecrets so that you can use a private registry for your image
   imagePullSecrets: []


### PR DESCRIPTION
Bump chart version to 0.7.0 to reflect the changes. 

It will be using 6.8.23 as base image so we're bumping all the child charts to 0.7.0 too.