### PR TITLE
SRC-1469 HPA template for Elasticsearch

### DIFF
--- a/charts/elasticsearch-umbrella/Chart.yaml
+++ b/charts/elasticsearch-umbrella/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -24,14 +24,14 @@ appVersion: 6.8.23
 # A list of the chart requirements 
 dependencies:
   - name: elasticsearch-statefulset
-    version: "0.7.0"
+    version: "0.8.0"
     alias: master
   - name: elasticsearch-statefulset
-    version: "0.7.0"
+    version: "0.8.0"
     alias: data
   - name: elasticsearch-statefulset
-    version: "0.7.0"
+    version: "0.8.0"
     alias: index
   - name: elasticsearch-deployment
-    version: "0.7.0"
+    version: "0.8.0"
     alias: client

--- a/charts/elasticsearch-umbrella/Chart.yaml
+++ b/charts/elasticsearch-umbrella/Chart.yaml
@@ -20,7 +20,7 @@ version: 0.8.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 6.8.23
+appVersion: 7.17.2
 # A list of the chart requirements 
 dependencies:
   - name: elasticsearch-statefulset

--- a/charts/elasticsearch-umbrella/README.md
+++ b/charts/elasticsearch-umbrella/README.md
@@ -1,6 +1,6 @@
 # elasticsearch-umbrella
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.8.23](https://img.shields.io/badge/AppVersion-6.8.23-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.8.23](https://img.shields.io/badge/AppVersion-6.8.23-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -8,10 +8,10 @@ A Helm chart for Kubernetes
 
 | Repository | Name | Version |
 |------------|------|---------|
-|  | client(elasticsearch-deployment) | 0.7.0 |
-|  | master(elasticsearch-statefulset) | 0.7.0 |
-|  | data(elasticsearch-statefulset) | 0.7.0 |
-|  | index(elasticsearch-statefulset) | 0.7.0 |
+|  | client(elasticsearch-deployment) | 0.8.0 |
+|  | master(elasticsearch-statefulset) | 0.8.0 |
+|  | data(elasticsearch-statefulset) | 0.8.0 |
+|  | index(elasticsearch-statefulset) | 0.8.0 |
 
 ## Values
 

--- a/charts/elasticsearch-umbrella/README.md
+++ b/charts/elasticsearch-umbrella/README.md
@@ -1,6 +1,6 @@
 # elasticsearch-umbrella
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.8.23](https://img.shields.io/badge/AppVersion-6.8.23-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.17.2](https://img.shields.io/badge/AppVersion-7.17.2-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -31,7 +31,7 @@ A Helm chart for Kubernetes
 | client.fullnameOverride | string | `""` | Overrides the clusterName and nodeGroup when used in the naming of resources. This should only be used when using a single nodeGroup, otherwise you will have name conflicts |
 | client.image.pullPolicy | string | `"IfNotPresent"` | The Kubernetes imagePullPolicy value |
 | client.image.repository | string | `"empathyco/elasticsearch"` | Docker repository for Elasticsearch image |
-| client.image.tag | string | `"6.8.23-memlock"` | Overrides the image tag whose default is the chart appVersion. |
+| client.image.tag | string | `"7.17.2-memlock"` | Overrides the image tag whose default is the chart appVersion. |
 | client.imagePullSecrets | list | `[]` | Configuration for imagePullSecrets so that you can use a private registry for your image |
 | client.ingress.annotations | object | `{}` | Annotations for Kubernetes Ingress |
 | client.ingress.className | string | `""` | IngressClass name for ingress exposition |
@@ -81,7 +81,7 @@ A Helm chart for Kubernetes
 | data.fullnameOverride | string | `""` | Overrides the clusterName and nodeGroup when used in the naming of resources. This should only be used when using a single nodeGroup, otherwise you will have name conflicts |
 | data.image.pullPolicy | string | `"IfNotPresent"` | The Kubernetes imagePullPolicy value |
 | data.image.repository | string | `"empathyco/elasticsearch"` | Docker repository for Elasticsearch image |
-| data.image.tag | string | `"6.8.23-memlock"` | Overrides the image tag whose default is the chart appVersion. |
+| data.image.tag | string | `"7.17.2-memlock"` | Overrides the image tag whose default is the chart appVersion. |
 | data.imagePullSecrets | list | `[]` | Configuration for imagePullSecrets so that you can use a private registry for your image |
 | data.ingress.annotations | object | `{}` | Annotations for Kubernetes Ingress |
 | data.ingress.className | string | `""` | IngressClass name for ingress exposition |
@@ -137,7 +137,7 @@ A Helm chart for Kubernetes
 | index.fullnameOverride | string | `""` | Overrides the clusterName and nodeGroup when used in the naming of resources. This should only be used when using a single nodeGroup, otherwise you will have name conflicts |
 | index.image.pullPolicy | string | `"IfNotPresent"` | The Kubernetes imagePullPolicy value |
 | index.image.repository | string | `"empathyco/elasticsearch"` | Docker repository for Elasticsearch image |
-| index.image.tag | string | `"6.8.23-memlock"` | Overrides the image tag whose default is the chart appVersion. |
+| index.image.tag | string | `"7.17.2-memlock"` | Overrides the image tag whose default is the chart appVersion. |
 | index.imagePullSecrets | list | `[]` | Configuration for imagePullSecrets so that you can use a private registry for your image |
 | index.ingress.annotations | object | `{}` | Annotations for Kubernetes Ingress |
 | index.ingress.className | string | `""` | IngressClass name for ingress exposition |
@@ -190,7 +190,7 @@ A Helm chart for Kubernetes
 | master.fullnameOverride | string | `""` | Overrides the clusterName and nodeGroup when used in the naming of resources. This should only be used when using a single nodeGroup, otherwise you will have name conflicts |
 | master.image.pullPolicy | string | `"IfNotPresent"` | The Kubernetes imagePullPolicy value |
 | master.image.repository | string | `"empathyco/elasticsearch"` | Docker repository for Elasticsearch image |
-| master.image.tag | string | `"6.8.23-memlock"` | Overrides the image tag whose default is the chart appVersion. |
+| master.image.tag | string | `"7.17.2-memlock"` | Overrides the image tag whose default is the chart appVersion. |
 | master.imagePullSecrets | list | `[]` | Configuration for imagePullSecrets so that you can use a private registry for your image |
 | master.ingress.annotations | object | `{}` | Annotations for Kubernetes Ingress |
 | master.ingress.className | string | `""` | IngressClass name for ingress exposition |

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/Chart.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/Chart.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/Chart.yaml
@@ -20,4 +20,4 @@ version: 0.8.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 6.8.23
+appVersion: 7.17.2

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/README.md
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/README.md
@@ -1,6 +1,6 @@
 # elasticsearch-deployment
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.8.23](https://img.shields.io/badge/AppVersion-6.8.23-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.8.23](https://img.shields.io/badge/AppVersion-6.8.23-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -10,6 +10,7 @@ A Helm chart for Kubernetes
 |-----|------|---------|-------------|
 | antiAffinity | string | `"soft"` |  |
 | antiAffinityTopologyKey | string | `"kubernetes.io/hostname"` |  |
+| autoscaling.enabled | bool | `false` | Enable/Disable autoscaling for the StatefulSet |
 | busybox.image | string | `"busybox:1.31"` | Image for busybox initContainers (sysctlInitContainer in official Elasticsearch Helm chart) |
 | elastic_config | object | `{"ES_JAVA_OPTS":"-Xms2048m -Xmx2048m","bootstrap.memory_lock":"true","network.bind_host":"0.0.0.0","node.data":"false","node.ingest":"false","node.master":"false","node.ml":"false","transport.tcp.compress":"true"}` | Elasticsearch configuration added in a configMap and passed to the Elasticsearch pods as Env. Vars. |
 | elastic_config."bootstrap.memory_lock" | string | `"true"` | Elasticsearch enable memory lock to avoid swapping |

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/README.md
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/README.md
@@ -10,6 +10,7 @@ A Helm chart for Kubernetes
 |-----|------|---------|-------------|
 | antiAffinity | string | `"soft"` |  |
 | antiAffinityTopologyKey | string | `"kubernetes.io/hostname"` |  |
+| antiAffinityWeight | string | `""` |  |
 | autoscaling.enabled | bool | `false` | Enable/Disable autoscaling for the StatefulSet |
 | busybox.image | string | `"busybox:1.31"` | Image for busybox initContainers (sysctlInitContainer in official Elasticsearch Helm chart) |
 | elastic_config | object | `{"ES_JAVA_OPTS":"-Xms2048m -Xmx2048m","bootstrap.memory_lock":"true","network.bind_host":"0.0.0.0","node.data":"false","node.ingest":"false","node.master":"false","node.ml":"false","transport.tcp.compress":"true"}` | Elasticsearch configuration added in a configMap and passed to the Elasticsearch pods as Env. Vars. |

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/README.md
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/README.md
@@ -1,6 +1,6 @@
 # elasticsearch-deployment
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.8.23](https://img.shields.io/badge/AppVersion-6.8.23-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.17.2](https://img.shields.io/badge/AppVersion-7.17.2-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -25,7 +25,7 @@ A Helm chart for Kubernetes
 | fullnameOverride | string | `""` | Overrides the clusterName and nodeGroup when used in the naming of resources. This should only be used when using a single nodeGroup, otherwise you will have name conflicts |
 | image.pullPolicy | string | `"IfNotPresent"` | The Kubernetes imagePullPolicy value |
 | image.repository | string | `"empathyco/elasticsearch"` | Docker repository for Elasticsearch image |
-| image.tag | string | `"6.8.23-memlock"` | Overrides the image tag whose default is the chart appVersion. |
+| image.tag | string | `"7.17.2-memlock"` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Configuration for imagePullSecrets so that you can use a private registry for your image |
 | ingress.annotations | object | `{}` | Annotations for Kubernetes Ingress |
 | ingress.className | string | `""` | IngressClass name for ingress exposition |

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/templates/deployment.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/templates/deployment.yaml
@@ -200,7 +200,7 @@ spec:
       {{- else if eq .Values.antiAffinity "soft" }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
+          - weight: {{ .Values.antiAffinityWeight |default 1 }}
             podAffinityTerm:
               topologyKey: {{ .Values.antiAffinityTopologyKey }}
               labelSelector:

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/templates/hpa.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/templates/hpa.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "deployment.fullname" . }}
+  labels:
+    {{- include "deployment.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "deployment.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: {{ .Values.autoscaling.scaleUp.stabilizationWindowSeconds }}
+      policies:
+        {{- range .Values.autoscaling.scaleUp.policies }}
+        - type: {{ .type }}
+          value: {{ .value }}
+          periodSeconds: {{ .periodSeconds }}
+        {{- end }}
+      selectPolicy: {{ .Values.autoscaling.scaleUp.selectPolicy }}
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.autoscaling.scaleDown.stabilizationWindowSeconds }}
+      policies:
+        {{- range .Values.autoscaling.scaleDown.policies}}
+        - type: {{ .type }}
+          value: {{ .value }}
+          periodSeconds: {{ .periodSeconds }}
+        {{- end }}
+      selectPolicy: {{ .Values.autoscaling.scaleDown.selectPolicy }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  {{- end }}

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/values.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/values.yaml
@@ -17,7 +17,7 @@ image:
   # -- The Kubernetes imagePullPolicy value
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.
-  tag: "6.8.23-memlock"
+  tag: "7.17.2-memlock"
   
 # -- Configuration for imagePullSecrets so that you can use a private registry for your image
 imagePullSecrets: []

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/values.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/values.yaml
@@ -5,6 +5,9 @@
 # -- Enabling or disabling master nodes
 enabled: true
 
+autoscaling:
+  # -- Enable/Disable autoscaling for the StatefulSet
+  enabled: false
 # -- Kubernetes replica count for the Statefulset (i.e. how many pods)
 replicaCount: 3
 

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/values.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/values.yaml
@@ -151,6 +151,14 @@ priorityClassName: ""
 # Changing this to a region would allow you to spread pods across regions
 antiAffinityTopologyKey: "kubernetes.io/hostname"
 
+# You can specify a weight between 1 and 100 for each instance of the
+# preferredDuringSchedulingIgnoredDuringExecution affinity type. 
+# When the scheduler finds nodes that meet all the other scheduling 
+# requirements of the Pod, the scheduler iterates through every
+# preferred rule that the node satisfies and adds the value of 
+# the weight for that expression to a sum.
+antiAffinityWeight: ""
+
 # Hard means that by default pods will only be scheduled if there are enough nodes for them
 # and that they will never end up on the same node. Setting this to soft will do this "best effort"
 antiAffinity: "soft"

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/Chart.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/Chart.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/Chart.yaml
@@ -20,4 +20,4 @@ version: 0.8.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 6.8.23
+appVersion: 7.17.2

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/README.md
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/README.md
@@ -1,6 +1,6 @@
 # elasticsearch-statefulset
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.8.23](https://img.shields.io/badge/AppVersion-6.8.23-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.17.2](https://img.shields.io/badge/AppVersion-7.17.2-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -27,7 +27,7 @@ A Helm chart for Kubernetes
 | fullnameOverride | string | `""` | Overrides the clusterName and nodeGroup when used in the naming of resources. This should only be used when using a single nodeGroup, otherwise you will have name conflicts |
 | image.pullPolicy | string | `"IfNotPresent"` | The Kubernetes imagePullPolicy value |
 | image.repository | string | `"empathyco/elasticsearch"` | Docker repository for Elasticsearch image |
-| image.tag | string | `"6.8.23-memlock"` | Overrides the image tag whose default is the chart appVersion. |
+| image.tag | string | `"7.17.2-memlock"` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Configuration for imagePullSecrets so that you can use a private registry for your image |
 | ingress.annotations | object | `{}` | Annotations for Kubernetes Ingress |
 | ingress.className | string | `""` | IngressClass name for ingress exposition |

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/README.md
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/README.md
@@ -1,6 +1,6 @@
 # elasticsearch-statefulset
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.8.23](https://img.shields.io/badge/AppVersion-6.8.23-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.8.23](https://img.shields.io/badge/AppVersion-6.8.23-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -10,6 +10,7 @@ A Helm chart for Kubernetes
 |-----|------|---------|-------------|
 | antiAffinity | string | `"soft"` |  |
 | antiAffinityTopologyKey | string | `"kubernetes.io/hostname"` |  |
+| autoscaling.enabled | bool | `false` | Enable/Disable autoscaling for the StatefulSet |
 | busybox.image | string | `"busybox:1.31"` | Image for busybox initContainers (sysctlInitContainer in official Elasticsearch Helm chart) |
 | elastic_config | object | `{"ES_JAVA_OPTS":"-Xms2048m -Xmx2048m","bootstrap.memory_lock":"true","logger.org.elasticsearch.discovery.gce":"TRACE","network.bind_host":"0.0.0.0","node.attr.type":"search","node.data":"true","node.ingest":"true","node.master":"false","node.ml":"false","transport.tcp.compress":"true"}` | Elasticsearch configuration added in a configMap and passed to the Elasticsearch pods as Env. Vars. |
 | elastic_config."bootstrap.memory_lock" | string | `"true"` | Elasticsearch enable memory lock to avoid swapping |

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/README.md
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/README.md
@@ -10,6 +10,7 @@ A Helm chart for Kubernetes
 |-----|------|---------|-------------|
 | antiAffinity | string | `"soft"` |  |
 | antiAffinityTopologyKey | string | `"kubernetes.io/hostname"` |  |
+| antiAffinityWeight | string | `""` |  |
 | autoscaling.enabled | bool | `false` | Enable/Disable autoscaling for the StatefulSet |
 | busybox.image | string | `"busybox:1.31"` | Image for busybox initContainers (sysctlInitContainer in official Elasticsearch Helm chart) |
 | elastic_config | object | `{"ES_JAVA_OPTS":"-Xms2048m -Xmx2048m","bootstrap.memory_lock":"true","logger.org.elasticsearch.discovery.gce":"TRACE","network.bind_host":"0.0.0.0","node.attr.type":"search","node.data":"true","node.ingest":"true","node.master":"false","node.ml":"false","transport.tcp.compress":"true"}` | Elasticsearch configuration added in a configMap and passed to the Elasticsearch pods as Env. Vars. |
@@ -39,7 +40,7 @@ A Helm chart for Kubernetes
 | nodeAffinity | object | `{}` |  |
 | nodeSelector | object | `{}` | Configurable nodeSelector so that you can target specific nodes for your Elasticsearch cluster |
 | podAnnotations | object | `{}` | Configurable annotations applied to all Elasticsearch pods |
-| podManagementPolicy | string | `""` | The default is to deploy all pods serially. By setting this to parallel all pods are started at the same time when bootstrapping the cluster |
+| podManagementPolicy | string | `""` | The default is to deploy all pods serially. By setting this to "Parallel" all pods are started at the same time when bootstrapping the cluster |
 | podSecurityContext | object | `{}` | Allows you to set the securityContext for the pod |
 | podSecurityPolicy.create | bool | `false` | Create a podSecurityPolicy with minimal permissions to run this Helm chart. Be sure to also set rbac.create to true, otherwise Role and RoleBinding won't be created. |
 | podSecurityPolicy.name | string | `""` | The name of the podSecurityPolicy to use. If not set and create is true, a name is generated using the fullname template |

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/hpa.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/hpa.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "statefulset.fullname" . }}
+  labels:
+    {{- include "statefulset.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: {{ include "statefulset.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: {{ .Values.autoscaling.scaleUp.stabilizationWindowSeconds }}
+      policies:
+        {{- range .Values.autoscaling.scaleUp.policies }}
+        - type: {{ .type }}
+          value: {{ .value }}
+          periodSeconds: {{ .periodSeconds }}
+        {{- end }}
+      selectPolicy: {{ .Values.autoscaling.scaleUp.selectPolicy }}
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.autoscaling.scaleDown.stabilizationWindowSeconds }}
+      policies:
+        {{- range .Values.autoscaling.scaleDown.policies}}
+        - type: {{ .type }}
+          value: {{ .value }}
+          periodSeconds: {{ .periodSeconds }}
+        {{- end }}
+      selectPolicy: {{ .Values.autoscaling.scaleDown.selectPolicy }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  {{- end }}

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/statefulset.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/statefulset.yaml
@@ -254,7 +254,7 @@ spec:
       {{- else if eq .Values.antiAffinity "soft" }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
+          - weight: {{ .Values.antiAffinityWeight |default 1 }}
             podAffinityTerm:
               topologyKey: {{ .Values.antiAffinityTopologyKey }}
               labelSelector:

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/values.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/values.yaml
@@ -7,6 +7,9 @@ enabled: true
 # -- This property indicates its the master
 isMaster: true
 
+autoscaling:
+  # -- Enable/Disable autoscaling for the StatefulSet
+  enabled: false
 # -- Kubernetes replica count for the StatefulSet (i.e. how many pods)
 replicaCount: 3
 

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/values.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/values.yaml
@@ -171,6 +171,14 @@ priorityClassName: ""
 # Changing this to a region would allow you to spread pods across regions
 antiAffinityTopologyKey: "kubernetes.io/hostname"
 
+# You can specify a weight between 1 and 100 for each instance of the
+# preferredDuringSchedulingIgnoredDuringExecution affinity type. 
+# When the scheduler finds nodes that meet all the other scheduling 
+# requirements of the Pod, the scheduler iterates through every
+# preferred rule that the node satisfies and adds the value of 
+# the weight for that expression to a sum.
+antiAffinityWeight: ""
+
 # Hard means that by default pods will only be scheduled if there are enough nodes for them
 # and that they will never end up on the same node. Setting this to soft will do this "best effort"
 antiAffinity: "soft"

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/values.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/values.yaml
@@ -19,7 +19,7 @@ image:
   # -- The Kubernetes imagePullPolicy value
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.
-  tag: "6.8.23-memlock"
+  tag: "7.17.2-memlock"
   
 # -- Configuration for imagePullSecrets so that you can use a private registry for your image
 imagePullSecrets: []
@@ -89,7 +89,7 @@ prometheus:
   # -- Exporter image to deploy as a sidecar container
     image: justwatch/elasticsearch_exporter:1.1.0
 
-# -- The default is to deploy all pods serially. By setting this to parallel all pods are started at
+# -- The default is to deploy all pods serially. By setting this to "Parallel" all pods are started at
 # the same time when bootstrapping the cluster
 podManagementPolicy: ""
 

--- a/charts/elasticsearch-umbrella/values.yaml
+++ b/charts/elasticsearch-umbrella/values.yaml
@@ -19,7 +19,7 @@ master:
     # -- The Kubernetes imagePullPolicy value
     pullPolicy: IfNotPresent
     # -- Overrides the image tag whose default is the chart appVersion.
-    tag: "6.8.23-memlock"
+    tag: "7.17.2-memlock"
 
   # -- Configuration for imagePullSecrets so that you can use a private registry for your image
   imagePullSecrets: []
@@ -93,6 +93,10 @@ master:
     exporter:
     # -- Exporter image to deploy as a sidecar container
       image: justwatch/elasticsearch_exporter:1.1.0
+
+  # -- The default is to deploy all pods serially. By setting this to "Parallel" all pods are started at
+  # the same time when bootstrapping the cluster
+  podManagementPolicy: "Parallel"
 
   # -- Configurable annotations applied to all Elasticsearch pods
   podAnnotations: {}
@@ -209,7 +213,7 @@ data:
     # -- The Kubernetes imagePullPolicy value
     pullPolicy: IfNotPresent
     # -- Overrides the image tag whose default is the chart appVersion.
-    tag: "6.8.23-memlock"
+    tag: "7.17.2-memlock"
     
   # -- Configuration for imagePullSecrets so that you can use a private registry for your image
   imagePullSecrets: []
@@ -397,7 +401,7 @@ index:
     # -- The Kubernetes imagePullPolicy value
     pullPolicy: IfNotPresent
     # -- Overrides the image tag whose default is the chart appVersion.
-    tag: "6.8.23-memlock"
+    tag: "7.17.2-memlock"
     
   # -- Configuration for imagePullSecrets so that you can use a private registry for your image
   imagePullSecrets: []
@@ -583,7 +587,7 @@ client:
     # -- The Kubernetes imagePullPolicy value
     pullPolicy: IfNotPresent
     # -- Overrides the image tag whose default is the chart appVersion.
-    tag: "6.8.23-memlock"
+    tag: "7.17.2-memlock"
     
   # -- Configuration for imagePullSecrets so that you can use a private registry for your image
   imagePullSecrets: []


### PR DESCRIPTION
This PR adds HPA v2 support for the Elasticsearch chart.

It exposes variables to configure:

- min/max replicas
- scale up and scale down policies
- cpu and memory metrics for the autoscaling

**NOTE:** Updated to ES 7.17.2 and set podManagementPolicy for "master" nodes as "Parallel" (since it's the default behaviour for bootstraping servers with 7.X"