### PR TITLE
SRC-1519 upgrade elastic exporter container to improve compatibility with newer versions

### DIFF
--- a/charts/elasticsearch-umbrella/Chart.yaml
+++ b/charts/elasticsearch-umbrella/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1
+version: 0.8.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -24,14 +24,14 @@ appVersion: 7.17.2
 # A list of the chart requirements 
 dependencies:
   - name: elasticsearch-statefulset
-    version: "0.8.1"
+    version: "0.8.2"
     alias: master
   - name: elasticsearch-statefulset
-    version: "0.8.1"
+    version: "0.8.2"
     alias: data
   - name: elasticsearch-statefulset
-    version: "0.8.1"
+    version: "0.8.2"
     alias: index
   - name: elasticsearch-deployment
-    version: "0.8.1"
+    version: "0.8.2"
     alias: client

--- a/charts/elasticsearch-umbrella/README.md
+++ b/charts/elasticsearch-umbrella/README.md
@@ -1,6 +1,6 @@
 # elasticsearch-umbrella
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.17.2](https://img.shields.io/badge/AppVersion-7.17.2-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.17.2](https://img.shields.io/badge/AppVersion-7.17.2-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -8,10 +8,10 @@ A Helm chart for Kubernetes
 
 | Repository | Name | Version |
 |------------|------|---------|
-|  | client(elasticsearch-deployment) | 0.8.0 |
-|  | master(elasticsearch-statefulset) | 0.8.0 |
-|  | data(elasticsearch-statefulset) | 0.8.0 |
-|  | index(elasticsearch-statefulset) | 0.8.0 |
+|  | client(elasticsearch-deployment) | 0.8.1 |
+|  | master(elasticsearch-statefulset) | 0.8.1 |
+|  | data(elasticsearch-statefulset) | 0.8.1 |
+|  | index(elasticsearch-statefulset) | 0.8.1 |
 
 ## Values
 
@@ -47,7 +47,7 @@ A Helm chart for Kubernetes
 | client.podSecurityPolicy.spec | object | `{}` | Spec to apply to the podSecurityPolicy. See values.yaml for an example |
 | client.prometheus.annotations | object | `{"app":"prometheus-operator","release":"prometheus"}` | Annotations to include in the ServiceMonitor |
 | client.prometheus.enabled | bool | `false` | Deploy a ServiceMonitor for Prometheus scrapping |
-| client.prometheus.exporter.image | string | `"justwatch/elasticsearch_exporter:1.1.0"` | Exporter image to deploy as a sidecar container |
+| client.prometheus.exporter.image | string | `"prometheuscommunity/elasticsearch-exporter:v1.3.0"` | Exporter image to deploy as a sidecar container |
 | client.prometheus.resources.limits.cpu | string | `"100m"` |  |
 | client.prometheus.resources.limits.memory | string | `"128Mi"` |  |
 | client.prometheus.resources.requests.cpu | string | `"100m"` |  |
@@ -98,7 +98,7 @@ A Helm chart for Kubernetes
 | data.podSecurityPolicy.spec | object | `{}` | Spec to apply to the podSecurityPolicy. See values.yaml for an example |
 | data.prometheus.annotations | object | `{"app":"prometheus-operator","release":"prometheus"}` | Annotations to include in the ServiceMonitor |
 | data.prometheus.enabled | bool | `false` | Deploy a ServiceMonitor for Prometheus scrapping |
-| data.prometheus.exporter.image | string | `"justwatch/elasticsearch_exporter:1.1.0"` | Exporter image to deploy as a sidecar container |
+| data.prometheus.exporter.image | string | `"prometheuscommunity/elasticsearch-exporter:v1.3.0"` | Exporter image to deploy as a sidecar container |
 | data.prometheus.resources.limits.cpu | string | `"100m"` |  |
 | data.prometheus.resources.limits.memory | string | `"128Mi"` |  |
 | data.prometheus.resources.requests.cpu | string | `"100m"` |  |
@@ -154,7 +154,7 @@ A Helm chart for Kubernetes
 | index.podSecurityPolicy.spec | object | `{}` | Spec to apply to the podSecurityPolicy. See values.yaml for an example |
 | index.prometheus.annotations | object | `{"app":"prometheus-operator","release":"prometheus"}` | Annotations to include in the ServiceMonitor |
 | index.prometheus.enabled | bool | `false` | Deploy a ServiceMonitor for Prometheus scrapping |
-| index.prometheus.exporter.image | string | `"justwatch/elasticsearch_exporter:1.1.0"` | Exporter image to deploy as a sidecar container |
+| index.prometheus.exporter.image | string | `"prometheuscommunity/elasticsearch-exporter:v1.3.0"` | Exporter image to deploy as a sidecar container |
 | index.prometheus.resources.limits.cpu | string | `"100m"` |  |
 | index.prometheus.resources.limits.memory | string | `"128Mi"` |  |
 | index.prometheus.resources.requests.cpu | string | `"100m"` |  |
@@ -201,6 +201,7 @@ A Helm chart for Kubernetes
 | master.nameOverride | string | `""` | Overrides the clusterName when used in the naming of resources |
 | master.nodeSelector | object | `{}` | Configurable nodeSelector so that you can target specific nodes for your Elasticsearch cluster |
 | master.podAnnotations | object | `{}` | Configurable annotations applied to all Elasticsearch pods |
+| master.podManagementPolicy | string | `"Parallel"` | The default is to deploy all pods serially. By setting this to "Parallel" all pods are started at the same time when bootstrapping the cluster |
 | master.podSecurityContext | object | `{}` | Allows you to set the securityContext for the pod |
 | master.podSecurityPolicy.create | bool | `false` | Create a podSecurityPolicy with minimal permissions to run this Helm chart. Be sure to also set rbac.create to true, otherwise Role and RoleBinding won't be created. |
 | master.podSecurityPolicy.name | string | `""` | The name of the podSecurityPolicy to use. If not set and create is true, a name is generated using the fullname template |
@@ -209,7 +210,7 @@ A Helm chart for Kubernetes
 | master.prometheus.dashboard.enabled | bool | `true` |  |
 | master.prometheus.dashboard.namespace | string | `"monitoring"` |  |
 | master.prometheus.enabled | bool | `false` | Deploy a ServiceMonitor for Prometheus scrapping |
-| master.prometheus.exporter.image | string | `"justwatch/elasticsearch_exporter:1.1.0"` | Exporter image to deploy as a sidecar container |
+| master.prometheus.exporter.image | string | `"prometheuscommunity/elasticsearch-exporter:v1.3.0"` | Exporter image to deploy as a sidecar container |
 | master.prometheus.resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Deploy a Grafana Dashboard |
 | master.rbac.create | bool | `false` | Whether RBAC rules should be created (Role and Rolebinding) |
 | master.replicaCount | int | `3` | Kubernetes replica count for the Statefulset (i.e. how many pods) |

--- a/charts/elasticsearch-umbrella/README.md
+++ b/charts/elasticsearch-umbrella/README.md
@@ -1,6 +1,6 @@
 # elasticsearch-umbrella
 
-![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.17.2](https://img.shields.io/badge/AppVersion-7.17.2-informational?style=flat-square)
+![Version: 0.8.2](https://img.shields.io/badge/Version-0.8.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.17.2](https://img.shields.io/badge/AppVersion-7.17.2-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -8,10 +8,10 @@ A Helm chart for Kubernetes
 
 | Repository | Name | Version |
 |------------|------|---------|
-|  | client(elasticsearch-deployment) | 0.8.1 |
-|  | master(elasticsearch-statefulset) | 0.8.1 |
-|  | data(elasticsearch-statefulset) | 0.8.1 |
-|  | index(elasticsearch-statefulset) | 0.8.1 |
+|  | client(elasticsearch-deployment) | 0.8.2 |
+|  | master(elasticsearch-statefulset) | 0.8.2 |
+|  | data(elasticsearch-statefulset) | 0.8.2 |
+|  | index(elasticsearch-statefulset) | 0.8.2 |
 
 ## Values
 

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/Chart.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1
+version: 0.8.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/README.md
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/README.md
@@ -1,6 +1,6 @@
 # elasticsearch-deployment
 
-![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.17.2](https://img.shields.io/badge/AppVersion-7.17.2-informational?style=flat-square)
+![Version: 0.8.2](https://img.shields.io/badge/Version-0.8.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.17.2](https://img.shields.io/badge/AppVersion-7.17.2-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/README.md
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/README.md
@@ -1,6 +1,6 @@
 # elasticsearch-deployment
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.17.2](https://img.shields.io/badge/AppVersion-7.17.2-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.17.2](https://img.shields.io/badge/AppVersion-7.17.2-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -45,7 +45,7 @@ A Helm chart for Kubernetes
 | prometheus.annotations | object | `{"app":"prometheus-operator","release":"prometheus"}` | Annotations to include in the ServiceMonitor |
 | prometheus.dashboard | object | `{"enabled":true,"namespace":"monitoring"}` | Deploy a Grafana Dashboard |
 | prometheus.enabled | bool | `true` | Deploy a ServiceMonitor for Prometheus scrapping |
-| prometheus.exporter.image | string | `"justwatch/elasticsearch_exporter:1.1.0"` | Exporter image to deploy as a sidecar container |
+| prometheus.exporter.image | string | `"prometheuscommunity/elasticsearch-exporter:v1.3.0"` | Exporter image to deploy as a sidecar container |
 | rbac.create | bool | `false` | Whether RBAC rules should be created (Role and Rolebinding) |
 | replicaCount | int | `3` | Kubernetes replica count for the Statefulset (i.e. how many pods) |
 | resources.limits.cpu | string | `"1000m"` | CPU limits for the Deployment |

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/values.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/values.yaml
@@ -71,7 +71,7 @@ prometheus:
     app: prometheus-operator
   exporter:
   # -- Exporter image to deploy as a sidecar container
-    image: justwatch/elasticsearch_exporter:1.1.0
+    image: prometheuscommunity/elasticsearch-exporter:v1.3.0
 
 # -- Configurable annotations applied to all Elasticsearch pods
 podAnnotations: {}

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/Chart.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1
+version: 0.8.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/README.md
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/README.md
@@ -1,6 +1,6 @@
 # elasticsearch-statefulset
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.17.2](https://img.shields.io/badge/AppVersion-7.17.2-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.17.2](https://img.shields.io/badge/AppVersion-7.17.2-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -49,7 +49,7 @@ A Helm chart for Kubernetes
 | prometheus.annotations | object | `{"app":"prometheus-operator","release":"prometheus"}` | Annotations to include in the ServiceMonitor |
 | prometheus.dashboard | object | `{"enabled":true,"namespace":"monitoring"}` | Deploy a Grafana Dashboard |
 | prometheus.enabled | bool | `true` | Deploy a ServiceMonitor for Prometheus scrapping |
-| prometheus.exporter.image | string | `"justwatch/elasticsearch_exporter:1.1.0"` | Exporter image to deploy as a sidecar container |
+| prometheus.exporter.image | string | `"prometheuscommunity/elasticsearch-exporter:v1.3.0"` | Exporter image to deploy as a sidecar container |
 | rbac.create | bool | `false` | Whether RBAC rules should be created (Role and Rolebinding) |
 | replicaCount | int | `3` | Kubernetes replica count for the StatefulSet (i.e. how many pods) |
 | resources.limits.cpu | string | `"1000m"` | CPU limits for the StatefulSet |

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/README.md
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/README.md
@@ -1,6 +1,6 @@
 # elasticsearch-statefulset
 
-![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.17.2](https://img.shields.io/badge/AppVersion-7.17.2-informational?style=flat-square)
+![Version: 0.8.2](https://img.shields.io/badge/Version-0.8.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.17.2](https://img.shields.io/badge/AppVersion-7.17.2-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/values.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/values.yaml
@@ -87,7 +87,7 @@ prometheus:
     app: prometheus-operator
   exporter:
   # -- Exporter image to deploy as a sidecar container
-    image: justwatch/elasticsearch_exporter:1.1.0
+    image: prometheuscommunity/elasticsearch-exporter:v1.3.0
 
 # -- The default is to deploy all pods serially. By setting this to "Parallel" all pods are started at
 # the same time when bootstrapping the cluster

--- a/charts/elasticsearch-umbrella/values.yaml
+++ b/charts/elasticsearch-umbrella/values.yaml
@@ -92,7 +92,7 @@ master:
       app: prometheus-operator
     exporter:
     # -- Exporter image to deploy as a sidecar container
-      image: justwatch/elasticsearch_exporter:1.1.0
+      image: prometheuscommunity/elasticsearch-exporter:v1.3.0
 
   # -- The default is to deploy all pods serially. By setting this to "Parallel" all pods are started at
   # the same time when bootstrapping the cluster
@@ -284,7 +284,7 @@ data:
       app: prometheus-operator
     exporter:
     # -- Exporter image to deploy as a sidecar container
-      image: justwatch/elasticsearch_exporter:1.1.0
+      image: prometheuscommunity/elasticsearch-exporter:v1.3.0
 
   # -- Configurable annotations applied to all Elasticsearch pods
   podAnnotations: {}
@@ -472,7 +472,7 @@ index:
       app: prometheus-operator
     exporter:
     # -- Exporter image to deploy as a sidecar container
-      image: justwatch/elasticsearch_exporter:1.1.0
+      image: prometheuscommunity/elasticsearch-exporter:v1.3.0
 
   # -- Configurable annotations applied to all Elasticsearch pods
   podAnnotations: {}
@@ -644,7 +644,7 @@ client:
       app: prometheus-operator
     exporter:
     # -- Exporter image to deploy as a sidecar container
-      image: justwatch/elasticsearch_exporter:1.1.0
+      image: prometheuscommunity/elasticsearch-exporter:v1.3.0
 
   # -- Configurable annotations applied to all Elasticsearch pods
   podAnnotations: {}


### PR DESCRIPTION
Looking into the elastic node logs I can see this kind of errros:

```
elasticsearch-master-0 elastic-exporter level=warn ts=2022-04-19T10:36:10.992349582Z caller=nodes.go:1851 msg="failed to fetch and decode node stats" err="json: cannot unmarshal array into Go struct field NodeStatsNodeResponse.http of type int"
```
It seems that the existing exporter is not fully compatible with newer ES version as we can see here: https://github.com/prometheus-community/elasticsearch_exporter/issues/516

It seems to be fixed in the latest version we're upgrading the container. The container that we were using is no longer available, it was created by https://github.com/orgs/justwatchcom/repositories but now it's migrated into https://github.com/prometheus-community/elasticsearch_exporter. As you can see, the release for 1.0.0 was from the original author.

Checking the command line instructions, it should be working with just changing the release. They don' mention any breaking change in the release notes.