### PR TITLE
SRC-1469 fix hpa autoscaling not working as expected

### DIFF
--- a/charts/elasticsearch-umbrella/Chart.yaml
+++ b/charts/elasticsearch-umbrella/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.2
+version: 0.8.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -24,14 +24,14 @@ appVersion: 7.17.2
 # A list of the chart requirements 
 dependencies:
   - name: elasticsearch-statefulset
-    version: "0.8.2"
+    version: "0.8.3"
     alias: master
   - name: elasticsearch-statefulset
-    version: "0.8.2"
+    version: "0.8.3"
     alias: data
   - name: elasticsearch-statefulset
-    version: "0.8.2"
+    version: "0.8.3"
     alias: index
   - name: elasticsearch-deployment
-    version: "0.8.2"
+    version: "0.8.3"
     alias: client

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/Chart.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.2
+version: 0.8.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/templates/deployment.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/templates/deployment.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- include "deployment.labels" . | nindent 4 }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "deployment.selectorLabels" . | nindent 6 }}

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/Chart.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.2
+version: 0.8.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/statefulset.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/statefulset.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- include "statefulset.labels" . | nindent 4 }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   {{- with .Values.podManagementPolicy }}
   podManagementPolicy: {{ . }}
   {{- end }}


### PR DESCRIPTION
Ignore `replicaCount` from values when autoscaling is enabled. So HPA is able to increment/decrement the amount of replicas.

Set chart version as 0.8.3