### PR TITLE
OPS-7063 - Fix typo in github action

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -31,6 +31,22 @@ jobs:
         with:
           version: "${{ env.HELM_VERSION }}"
 
+      - name: Add Helm repositories
+        run: |
+          # Install yq tool to parse Chart.yaml to identify Helm dependencies repositories
+          wget https://github.com/mikefarah/yq/releases/download/v4.21.1/yq_linux_386 -O /usr/bin/yq && chmod +x /usr/bin/yq
+          # Retrieve all helm dependencies repositories and run `helm repo add` for each of them.
+          # Command explanation follows:
+          #
+          # yq '.dependencies.[].repository' helm/*/Chart.yaml --> Prints repository field for all Chart dependencies.
+          # sed 's:/*$::' --> Trims the trailing forward slash '/' at the end of the repository URL, if any
+          # sort | uniq ----> Removes duplicated entries, for those cases where more than 1 dependency comes
+          #                   from the same Helm repository
+          yq '.dependencies.[].repository' helm/*/Chart.yaml | awk '/^http/' | sed 's:/*$::' | sort | uniq | while read helm_repo; do
+            # Helm repo name is generated from a random string, as it is not persisted between executions.
+            helm repo add $(openssl rand -hex 12) ${helm_repo}
+          done
+
       - name: "Run chart-releaser"
         uses: helm/chart-releaser-action@v1.2.0
         with:

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -42,7 +42,7 @@ jobs:
           # sed 's:/*$::' --> Trims the trailing forward slash '/' at the end of the repository URL, if any
           # sort | uniq ----> Removes duplicated entries, for those cases where more than 1 dependency comes
           #                   from the same Helm repository
-          yq '.dependencies.[].repository' helm/*/Chart.yaml | awk '/^http/' | sed 's:/*$::' | sort | uniq | while read helm_repo; do
+          yq '.dependencies.[].repository' charts/*/Chart.yaml | awk '/^http/' | sed 's:/*$::' | sort | uniq | while read helm_repo; do
             # Helm repo name is generated from a random string, as it is not persisted between executions.
             helm repo add $(openssl rand -hex 12) ${helm_repo}
           done


### PR DESCRIPTION
**Jira issue: [OPS-7063](https://searchbroker.atlassian.net/browse/OPS-7063)**

- Fix typo in github action `chart-release.yaml`.