### PR TITLE
OPS-7065 - Handle devlake secrets as key:value pairs instead of a key containing all the file content

### DIFF
--- a/charts/devlake/Chart.yaml
+++ b/charts/devlake/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for DevLake
 
 type: application
 
-version: 1.0.1
+version: 1.0.2
 
 appVersion: "0.10.0"
 

--- a/charts/devlake/templates/devlake/dev-lake-deployment.yaml
+++ b/charts/devlake/templates/devlake/dev-lake-deployment.yaml
@@ -36,13 +36,10 @@ spec:
           - name: env-cm
             mountPath: /appenv/env-cm
             subPath: env-cm
-          - name: env-secret
-            mountPath: /appenv/env-secret
-            subPath: env-secret
           command:
             - sh
             - -c
-            - "cat /appenv/env* > /tmp/config/.env && chmod 644 /tmp/config/.env"
+            - "env|grep -E '^PLACEHOLDER_'|sed 's/^PLACEHOLDER_//g' > /tmp/env-secret && cat /appenv/env-cm /tmp/env-secret > /tmp/config/.env && chmod 644 /tmp/config/.env"
         {{- if .Values.mysql.enabled }}    
         - name: busybox-mysql
           image: busybox
@@ -86,9 +83,6 @@ spec:
         - name: env-cm
           configMap:
             name: {{ include "devlake.fullname" . }}-env-config
-        - name: env-secret
-          secret:
-            secretName: {{.Values.devlake.dotEnvFileSecretName}}
       securityContext:
         runAsNonRoot: true 
         runAsUser: 1000


### PR DESCRIPTION
**Jira issue: [OPS-7065](https://searchbroker.atlassian.net/browse/OPS-7065)**

In order to reuse the content of the provided secret in order workloads as environment variables, let's use key:value pairs to create the secret instead of using a single key with all the values inside.

Before (base64 encoded):
```yaml
apiVersion: v1
kind: Secret
data:
  env-secret: Rk9PPWJhcgpCT089YmF6Cg==
```

After:
```yaml
apiVersion: v1
kind: Secret
data:
  PLACEHOLDER_FOO: bar
  PLACEHOLDER_BOO: baz
```

Then use the initContainer `busybox-init` to filter the environment variables that begins with `PLACEHOLDER_`, remove the `PLACEHOLDER_` from the name, and store the content in a file. Then use that file along with the `env-cm` to generate the final `.env`file to be read by the application.

For this example, the environment variables `PLACEHOLDER_FOO` and `PLACEHOLDER_BOO` will end up being just  `FOO` and `BOO` in the final `.env` file

Regards.
