### PR TITLE
OPS-7175 - Update ports used by ConfigUI in the new docker image

### DIFF
--- a/charts/devlake/Chart.yaml
+++ b/charts/devlake/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for DevLake
 
 type: application
 
-version: 1.0.3
+version: 1.0.4
 
 appVersion: "0.10.0"
 

--- a/charts/devlake/templates/configui/config-ui-deployment.yaml
+++ b/charts/devlake/templates/configui/config-ui-deployment.yaml
@@ -35,7 +35,7 @@ spec:
           imagePullPolicy: {{ .Values.configui.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ default "4000" .Values.configui.containerPortOverride }}
               protocol: TCP
           livenessProbe:
           {{- if .Values.configui.envFromSecret }}
@@ -43,7 +43,7 @@ spec:
               command:
                 - "sh"
                 - "-c"
-                - "curl -s -u ${ADMIN_USER}:${ADMIN_PASS} http://localhost:80"
+                - "curl -s -u ${ADMIN_USER}:${ADMIN_PASS} http://localhost:{{ default "4000" .Values.configui.containerPortOverride }}"
           {{- else}}
             httpGet:
               path: /
@@ -55,7 +55,7 @@ spec:
               command:
                 - "sh"
                 - "-c"
-                - "curl -s -u ${ADMIN_USER}:${ADMIN_PASS} http://localhost:80"
+                - "curl -s -u ${ADMIN_USER}:${ADMIN_PASS} http://localhost:{{ default "4000" .Values.configui.containerPortOverride }}"
           {{- else}}
             httpGet:
               path: /

--- a/charts/devlake/templates/devlake/dev-lake-deployment.yaml
+++ b/charts/devlake/templates/devlake/dev-lake-deployment.yaml
@@ -61,7 +61,7 @@ spec:
           imagePullPolicy: {{ .Values.devlake.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: {{ default 8080 .Values.devlake.containerPortOverride }}
               protocol: TCP
           volumeMounts:
           - name: shared


### PR DESCRIPTION
**Jira issue: [OPS-7175]**

## Motivation

Use the official images from Apache instead the ones from Merico, even though they are the official maintainers, the images provided by Merico may contain not stable code.

## Changes.

- Update ports used by the docker image, making it able to override them from the values if needed.

[OPS-7175]: https://searchbroker.atlassian.net/browse/OPS-7175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ