### PR TITLE
Update nonexistent default 'test' image

### DIFF
--- a/charts/multi-service-deployment/Chart.yaml
+++ b/charts/multi-service-deployment/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/multi-service-deployment/values.yaml
+++ b/charts/multi-service-deployment/values.yaml
@@ -2,9 +2,9 @@ fullnameOverride: ""
 replicaCount: 1
 
 image:
-  repository: ""
+  repository: hello-world
+  tag: latest
   pullPolicy: IfNotPresent
-  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/multi-service-deployment/values.yaml
+++ b/charts/multi-service-deployment/values.yaml
@@ -2,7 +2,7 @@ fullnameOverride: ""
 replicaCount: 1
 
 image:
-  repository: test
+  repository: ""
   pullPolicy: IfNotPresent
   tag: ""
 


### PR DESCRIPTION
We're receiving daily notifications from ArtifactHub vulnerability scannings with errors because it's not able to find the image specified in this chart:

<img width="582" alt="image" src="https://user-images.githubusercontent.com/15369573/185050794-e6563886-d17a-47fc-8961-8c26da2c65df.png">

Updating it to use https://hub.docker.com/_/hello-world/tags