### PR TITLE
fix/OPS-7503 - Fix elasticsearch-umbrella affinity configuration

### DIFF
--- a/charts/elasticsearch-umbrella/Chart.yaml
+++ b/charts/elasticsearch-umbrella/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.4
+version: 0.8.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -24,14 +24,14 @@ appVersion: 7.17.2
 # A list of the chart requirements 
 dependencies:
   - name: elasticsearch-statefulset
-    version: "0.8.4"
+    version: "0.8.5"
     alias: master
   - name: elasticsearch-statefulset
-    version: "0.8.4"
+    version: "0.8.5"
     alias: data
   - name: elasticsearch-statefulset
-    version: "0.8.4"
+    version: "0.8.5"
     alias: index
   - name: elasticsearch-deployment
-    version: "0.8.4"
+    version: "0.8.5"
     alias: client

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/Chart.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.4
+version: 0.8.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/templates/_helpers.tpl
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/templates/_helpers.tpl
@@ -46,7 +46,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "deployment.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "deployment.name" . }}
+app.kubernetes.io/name: {{ include "deployment.fullname" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/templates/deployment.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/templates/deployment.yaml
@@ -198,7 +198,7 @@ spec:
               - key: "app.kubernetes.io/name"
                 operator: In
                 values:
-                - {{ include "statefulset.fullname" . }}
+                - {{ include "deployment.fullname" . }}
             topologyKey: {{ .Values.antiAffinityTopologyKey }}
       {{- else if eq .Values.antiAffinity "soft" }}
         podAntiAffinity:
@@ -211,7 +211,7 @@ spec:
                 - key: "app.kubernetes.io/name"
                   operator: In
                   values:
-                  - {{ include "statefulset.fullname" . }}
+                  - {{ include "deployment.fullname" . }}
       {{- end }}
       {{- with .Values.nodeAffinity }}
         nodeAffinity:

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/templates/deployment.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/templates/deployment.yaml
@@ -190,6 +190,9 @@ spec:
       {{- end }}
       affinity:
       {{- end }}
+      {{- if .Values.affinityOverride }}
+        {{- toYaml .Values.affinityOverride | nindent 8 }}
+      {{- else }}
       {{- if eq .Values.antiAffinity "hard" }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -212,6 +215,7 @@ spec:
                   operator: In
                   values:
                   - {{ include "deployment.fullname" . }}
+      {{- end }}
       {{- end }}
       {{- with .Values.nodeAffinity }}
         nodeAffinity:

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/values.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/values.yaml
@@ -161,6 +161,9 @@ antiAffinityWeight: ""
 # and that they will never end up on the same node. Setting this to soft will do this "best effort"
 antiAffinity: "soft"
 
+# Overrides Pod affinity with custom settings.
+affinityOverride:  {}
+
 # This is the node affinity settings as defined in
 # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
 nodeAffinity: {}

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/Chart.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.4
+version: 0.8.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/_helpers.tpl
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/_helpers.tpl
@@ -46,7 +46,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "statefulset.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "statefulset.name" . }}
+app.kubernetes.io/name: {{ include "statefulset.fullname" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/statefulset.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/statefulset.yaml
@@ -244,6 +244,9 @@ spec:
       {{- end }}
       affinity:
       {{- end }}
+      {{- if .Values.affinityOverride }}
+        {{- toYaml .Values.affinityOverride | nindent 8 }}
+      {{- else }}
       {{- if eq .Values.antiAffinity "hard" }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -266,6 +269,7 @@ spec:
                   operator: In
                   values:
                   - {{ include "statefulset.fullname" . }}
+      {{- end }}
       {{- end }}
       {{- with .Values.nodeAffinity }}
         nodeAffinity:

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/values.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/values.yaml
@@ -181,6 +181,9 @@ antiAffinityWeight: ""
 # and that they will never end up on the same node. Setting this to soft will do this "best effort"
 antiAffinity: "soft"
 
+# Overrides Pod affinity with custom settings.
+affinityOverride:  {}
+
 # This is the node affinity settings as defined in
 # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
 nodeAffinity: {}

--- a/charts/elasticsearch-umbrella/values.yaml
+++ b/charts/elasticsearch-umbrella/values.yaml
@@ -197,6 +197,8 @@ master:
       #  - persistentVolumeClaim
       #  - emptyDir
 
+  affinityOverride: {}
+
 data:
   # -- Enabling or disabling data nodes
   enabled: true
@@ -382,6 +384,8 @@ data:
       #  - configMap
       #  - persistentVolumeClaim
       #  - emptyDir
+
+  affinityOverride: {}
 
 index:
   # -- Enabling or disabling index nodes
@@ -569,6 +573,8 @@ index:
       #  - persistentVolumeClaim
       #  - emptyDir
 
+  affinityOverride: {}
+
 client:
   # -- Enabling or disabling client nodes
   enabled: true
@@ -738,3 +744,5 @@ client:
       #  - configMap
       #  - persistentVolumeClaim
       #  - emptyDir
+
+  affinityOverride: {}


### PR DESCRIPTION
**Jira issue: [OPS-7503]**

## Motivation

**Description fetched from the issue:**

The current chart used by the Search team allows configuring pod anti-affinity using the values `soft` or `hard` and a topology key that defaults to `kubernetes.io/hostname`

The problem is the label selector uses the `app.kubernetes.io/name` label but the label value doesn’t match with the actual statefulSet.

For example, the label selector uses `elasticsearch-data`:

```yaml
podAntiAffinity:
  requiredDuringSchedulingIgnoredDuringExecution:
    - labelSelector:
        matchExpressions:
          - key: app.kubernetes.io/name
            operator: In
            values:
              - elasticsearch-data
      topologyKey: kubernetes.io/hostname
```

while the statefulSet/pods have the label as `app.kubernetes.io/name=data`

This is preventing configuring the podAntiAffinity to avoid multiple pods being scheduled in the same host.

## Changes

- Helper function `statefulset.selectorLabels` updated to use `statefulset.fullname` instead of `statefulset.name`. This changes has been applied in both deployment and statefulset subcharts.
- Fixed wrong references to helper functions in the `elasticsearch-deployment` subchart, as it was referring to functions from the `elasticsearch-statefulset` one.
- Bump version of the elasticsearch-umbrella and subcharts to 0.8.5

## Comments

Following a couple of screenshots with the changes in the rendered manifests:

![image](https://user-images.githubusercontent.com/16705936/194308473-ea65d551-f353-4b41-8ea6-5e8696ae298d.png)
![image](https://user-images.githubusercontent.com/16705936/194308583-9e2e2b62-ee11-4c50-891f-2f8f8638cfe8.png)

As now `fullname` is used, it will always match the selector, no matter whether using the default helm chart values or altering the defaults with `fullnameOverride`.

Note that as this implies changing a label of the statefulset pods, it is required to delete the statefulset without deleting its Pods for the new version to deploy correctly.

```
kubectl delete statefulset <elasticsearch-data-sts-name> --cascade=orphan
```

Note that depending on the Kubernetes version, it could be `--cascade=false` instead of `--cascade=orphan`.

Regards.

[OPS-7503]: https://searchbroker.atlassian.net/browse/OPS-7503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ