### PR TITLE
Fix elasticsearch umbrella PodDisruptionBudget and StatefulSet volumeClaimTemplate labeling

### DIFF
--- a/charts/elasticsearch-umbrella/Chart.yaml
+++ b/charts/elasticsearch-umbrella/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.6
+version: 0.8.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -24,14 +24,14 @@ appVersion: 7.17.2
 # A list of the chart requirements 
 dependencies:
   - name: elasticsearch-statefulset
-    version: "0.8.6"
+    version: "0.8.7"
     alias: master
   - name: elasticsearch-statefulset
-    version: "0.8.6"
+    version: "0.8.7"
     alias: data
   - name: elasticsearch-statefulset
-    version: "0.8.6"
+    version: "0.8.7"
     alias: index
   - name: elasticsearch-deployment
-    version: "0.8.6"
+    version: "0.8.7"
     alias: client

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/Chart.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.6
+version: 0.8.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/templates/pdb.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/templates/pdb.yaml
@@ -13,5 +13,5 @@ spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "deployment.name" . }}
+      {{- include "statefulset.selectorLabels" . | nindent 6 }}
 {{- end -}}

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/Chart.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.6
+version: 0.8.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/pdb.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/pdb.yaml
@@ -13,5 +13,5 @@ spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "statefulset.name" . }}
+      {{- include "statefulset.selectorLabels" . | nindent 6 }}
 {{- end -}}

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/statefulset.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/statefulset.yaml
@@ -285,8 +285,6 @@ spec:
         annotations:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        labels:
-        {{- include "statefulset.labels" . | nindent 10 }}
         name: data
       spec:
         accessModes:


### PR DESCRIPTION
**Jira issues:**
  - **[OPS-7670]**
  - **[OPS-7680]**

## Motivation

**[OPS-7670]**

`PodDisruptionBudget` resources were broken as part of a bug introduced in #96. PDB started to mismatch Elasticsearch Pod labels:

PodDisruptionBudget selector looks like follows:
```yaml
spec:
  maxUnavailable: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: data
```

But Elasticsearch Pods were using a diffferent value for the label`app.kubernetes.io/name`

```yaml
apiVersion: v1
kind: Pod
metadata:
  labels:
    app.kubernetes.io/instance: elasticsearch
    app.kubernetes.io/name: elasticsearch-data <------------- "elasticsearch-data" instead of just "data"
    controller-revision-hash: elasticsearch-data-77584bfbdb
    statefulset.kubernetes.io/pod-name: elasticsearch-data-0
```

**[OPS-7680]**

Every time updating to a newer release of the `elasticsearch-umbrella` Helm Chart it required orphaning the StatefulSet and the perform the update. Otherwise the following error was raised:

> Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden.

What makes the upgrade process uncomfortable and prone to downtime as it would be more likely to make a mistake deleting the StatefulSet, for example, deleting it without orphaning the Pods would end up with an outage.

## Changes

**[OPS-7670]**

- Remove labels from StatefulSet's `.spec.volumeClaimTemplates`. The created PVC still contains the labels from the StatefulSet, so it still possible to map costs to workloads, etc.

**[OPS-7680]**
- Use the helper function `statefulset.selectorLabels` in the selector of the PodDisruptionBudget resource. This way we ensure the same selector used by the service is used by the PDB, so the same Pods are going to be matched.

## Comments

- Note that upgrading an existing release might still require orphaning the StatefulSet, as it would contain the labels from the previous intallation, but future installation would be smooth.

[OPS-7670]: https://searchbroker.atlassian.net/browse/OPS-7670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OPS-7680]: https://searchbroker.atlassian.net/browse/OPS-7680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OPS-7670]: https://searchbroker.atlassian.net/browse/OPS-7670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OPS-7680]: https://searchbroker.atlassian.net/browse/OPS-7680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OPS-7670]: https://searchbroker.atlassian.net/browse/OPS-7670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ