### PR TITLE
OPS-7670 - Handle compatibility of PodDisruptionBudget apiVersion

### DIFF
--- a/charts/elasticsearch-umbrella/Chart.yaml
+++ b/charts/elasticsearch-umbrella/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.7
+version: 0.8.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -24,14 +24,14 @@ appVersion: 7.17.2
 # A list of the chart requirements 
 dependencies:
   - name: elasticsearch-statefulset
-    version: "0.8.7"
+    version: "0.8.8"
     alias: master
   - name: elasticsearch-statefulset
-    version: "0.8.7"
+    version: "0.8.8"
     alias: data
   - name: elasticsearch-statefulset
-    version: "0.8.7"
+    version: "0.8.8"
     alias: index
   - name: elasticsearch-deployment
-    version: "0.8.7"
+    version: "0.8.8"
     alias: client

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/Chart.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.7
+version: 0.8.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/templates/pdb.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/templates/pdb.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.enabled -}}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: policy/v1
+{{- else -}}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "deployment.serviceAccountName" . }}

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/Chart.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.7
+version: 0.8.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/pdb.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/pdb.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.enabled -}}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: policy/v1
+{{- else -}}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "statefulset.serviceAccountName" . }}


### PR DESCRIPTION
**Jira issue: [OPS-7670]**
 
## Motivation

PodDisruptionBudget api version `policy/v1beta1` has been deprecated in Kubernetes version 1.21, and it will be removed in Kubernetes version 1.25:
> W1103 16:02:16.839814   56553 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget

So we are implementing a simple logic to use either one depending on the Kubernetes version of the cluster where the chart is deployed.

## Changes

- Added logic to set apiVersion in elasticsearch-deployment PDB template.
- Added logic to set apiVersion in elasticsearch-statefulset PDB template.
- Bump Chart version to 0.8.8

## Comments

Testing:

```shell
❯ helm template . -s charts/data/templates/pdb.yaml --kube-version 1.20 | yq '.apiVersion'
policy/v1beta1

❯ helm template . -s charts/data/templates/pdb.yaml --kube-version 1.21 | yq '.apiVersion'
policy/v1
```

[OPS-7670]: https://searchbroker.atlassian.net/browse/OPS-7670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ