### PR TITLE
OPS-7966 - Extra InitContainers and volumes

### DIFF
--- a/.github/workflows/pr-helm-lint.yaml
+++ b/.github/workflows/pr-helm-lint.yaml
@@ -18,16 +18,16 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: "Checkout current PR"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Checkout main branch"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: main
           path: main
 
       - name: "Install Helm"
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3.5
         with:
           version: "${{ env.HELM_VERSION }}"
 
@@ -37,7 +37,7 @@ jobs:
           chmod u+x gomplate
 
       - name: "Get Helm Charts changed"
-        uses: jitterbit/get-changed-files@v1
+        uses: masesgroup/retrieve-changed-files@v2
         id: updated_files
         with:
           format: csv

--- a/charts/elasticsearch-umbrella/Chart.yaml
+++ b/charts/elasticsearch-umbrella/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.8
+version: 0.8.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -24,14 +24,14 @@ appVersion: 7.17.2
 # A list of the chart requirements 
 dependencies:
   - name: elasticsearch-statefulset
-    version: "0.8.8"
+    version: "0.8.9"
     alias: master
   - name: elasticsearch-statefulset
-    version: "0.8.8"
+    version: "0.8.9"
     alias: data
   - name: elasticsearch-statefulset
-    version: "0.8.8"
+    version: "0.8.9"
     alias: index
   - name: elasticsearch-deployment
-    version: "0.8.8"
+    version: "0.8.9"
     alias: client

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/Chart.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.8
+version: 0.8.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/templates/deployment.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/templates/deployment.yaml
@@ -90,6 +90,10 @@ spec:
           volumeMounts:
             - mountPath: /data
               name: storage
+            {{- with .Values.extraVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+
 
         {{ if .Values.prometheus.enabled }}
         
@@ -176,10 +180,18 @@ spec:
           name: increase-fd-unlimited
           securityContext:
             privileged: true
+        {{- with .Values.extraInitContainers }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+
       volumes:
       - emptyDir:
           medium: ""
         name: storage
+      {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/values.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/values.yaml
@@ -195,3 +195,26 @@ podSecurityPolicy:
     #   - configMap
     #   - persistentVolumeClaim
     #   - emptyDir
+
+# -- Extra initContainers to be run after the ones needed by Elasticsearch
+extraInitContainers: []
+  #- command:
+  #  - sh
+  #  - -c
+  #  - |
+  #    echo "Hello World"
+  #  image: busybox:1.31
+  #  imagePullPolicy: IfNotPresent
+  #  name: my-init-container
+
+# -- Extra volumes, these can be later mounted on the extraInitContainers or to the Elasticsearch container.
+extraVolumes: []
+  #- name: foo
+  #  configMap:
+  #    name: myconfigmap
+
+# -- Extra volume to mount to the Elasticsearch container. Those must be first specified in the extraVolumes field.
+extraVolumeMounts: []
+  #- name: foo
+  #  mountPath: "/etc/foo"
+  #  readOnly: true

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/Chart.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.8
+version: 0.8.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/statefulset.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/statefulset.yaml
@@ -26,6 +26,10 @@ spec:
       labels:
         {{- include "statefulset.selectorLabels" . | nindent 8 }}
     spec:
+      volumes:
+      {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -89,6 +93,9 @@ spec:
           volumeMounts:
             - mountPath: /usr/share/elasticsearch/data
               name: data
+          {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{ if .Values.isMaster }}      
         - command:
           - sh
@@ -234,6 +241,9 @@ spec:
           name: increase-fd-unlimited
           securityContext:
             privileged: true
+        {{- with .Values.extraInitContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/values.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/values.yaml
@@ -215,3 +215,26 @@ podSecurityPolicy:
     #   - configMap
     #   - persistentVolumeClaim
     #   - emptyDir
+
+# -- Extra initContainers to be run after the ones needed by Elasticsearch
+extraInitContainers: []
+  #- command:
+  #  - sh
+  #  - -c
+  #  - |
+  #    echo "Hello World"
+  #  image: busybox:1.31
+  #  imagePullPolicy: IfNotPresent
+  #  name: my-init-container
+
+# -- Extra volumes, these can be later mounted on the extraInitContainers or to the Elasticsearch container.
+extraVolumes: []
+  #- name: foo
+  #  configMap:
+  #    name: myconfigmap
+
+# -- Extra volume to mount to the Elasticsearch container. Those must be first specified in the extraVolumes field.
+extraVolumeMounts: []
+  #- name: foo
+  #  mountPath: "/etc/foo"
+  #  readOnly: true

--- a/charts/elasticsearch-umbrella/values.yaml
+++ b/charts/elasticsearch-umbrella/values.yaml
@@ -20,7 +20,7 @@ master:
     # -- The Kubernetes imagePullPolicy value
     pullPolicy: IfNotPresent
     # -- Overrides the image tag whose default is the chart appVersion.
-    tag: "7.17.7-memlock-repo-plugins"
+    tag: "7.17.2-memlock"
 
   # -- Configuration for imagePullSecrets so that you can use a private registry for your image
   imagePullSecrets: []
@@ -231,7 +231,7 @@ data:
     # -- The Kubernetes imagePullPolicy value
     pullPolicy: IfNotPresent
     # -- Overrides the image tag whose default is the chart appVersion.
-    tag: "7.17.7-memlock-repo-plugins"
+    tag: "7.17.2-memlock"
     
   # -- Configuration for imagePullSecrets so that you can use a private registry for your image
   imagePullSecrets: []

--- a/charts/elasticsearch-umbrella/values.yaml
+++ b/charts/elasticsearch-umbrella/values.yaml
@@ -58,7 +58,7 @@ master:
     # -- Elasticsearch ml node role
     node.ml: "false"
     # -- Elasticsearch JVM options
-    ES_JAVA_OPTS: "-Xms1024m -Xmx1024m"
+    #ES_JAVA_OPTS: "-Xms2048m -Xmx2048m"
     # -- Elasticsearch enable compression between nodes
     transport.tcp.compress: "true"
     # -- Elasticsearch enable memory lock to avoid swapping

--- a/charts/elasticsearch-umbrella/values.yaml
+++ b/charts/elasticsearch-umbrella/values.yaml
@@ -6,7 +6,6 @@ global:
   masterFullname: es-master
 
 master:
-
   # -- Enabling or disabling master nodes
   enabled: true
   # -- This property indicates its the master

--- a/charts/elasticsearch-umbrella/values.yaml
+++ b/charts/elasticsearch-umbrella/values.yaml
@@ -6,6 +6,7 @@ global:
   masterFullname: es-master
 
 master:
+
   # -- Enabling or disabling master nodes
   enabled: true
   # -- This property indicates its the master
@@ -19,7 +20,7 @@ master:
     # -- The Kubernetes imagePullPolicy value
     pullPolicy: IfNotPresent
     # -- Overrides the image tag whose default is the chart appVersion.
-    tag: "7.17.2-memlock"
+    tag: "7.17.7-memlock-repo-plugins"
 
   # -- Configuration for imagePullSecrets so that you can use a private registry for your image
   imagePullSecrets: []
@@ -57,7 +58,7 @@ master:
     # -- Elasticsearch ml node role
     node.ml: "false"
     # -- Elasticsearch JVM options
-    #ES_JAVA_OPTS: "-Xms2048m -Xmx2048m"
+    ES_JAVA_OPTS: "-Xms1024m -Xmx1024m"
     # -- Elasticsearch enable compression between nodes
     transport.tcp.compress: "true"
     # -- Elasticsearch enable memory lock to avoid swapping
@@ -193,6 +194,29 @@ master:
 
   affinityOverride: {}
 
+  # -- Extra initContainers to be run after the ones needed by Elasticsearch
+  extraInitContainers: []
+    #- command:
+    #  - sh
+    #  - -c
+    #  - |
+    #    echo "Hello World"
+    #  image: busybox:1.31
+    #  imagePullPolicy: IfNotPresent
+    #  name: my-init-container
+
+  # -- Extra volumes, these can be later mounted on the extraInitContainers or to the Elasticsearch container.
+  extraVolumes: []
+    #- name: foo
+    #  configMap:
+    #    name: myconfigmap
+
+  # -- Extra volume to mount to the Elasticsearch container. Those must be first specified in the extraVolumes field.
+  extraVolumeMounts: []
+    #- name: foo
+    #  mountPath: "/etc/foo"
+    #  readOnly: true
+
 data:
   # -- Enabling or disabling data nodes
   enabled: true
@@ -207,7 +231,7 @@ data:
     # -- The Kubernetes imagePullPolicy value
     pullPolicy: IfNotPresent
     # -- Overrides the image tag whose default is the chart appVersion.
-    tag: "7.17.2-memlock"
+    tag: "7.17.7-memlock-repo-plugins"
     
   # -- Configuration for imagePullSecrets so that you can use a private registry for your image
   imagePullSecrets: []
@@ -374,6 +398,29 @@ data:
       #  - emptyDir
 
   affinityOverride: {}
+
+  # -- Extra initContainers to be run after the ones needed by Elasticsearch
+  extraInitContainers: []
+    #- command:
+    #  - sh
+    #  - -c
+    #  - |
+    #    echo "Hello World"
+    #  image: busybox:1.31
+    #  imagePullPolicy: IfNotPresent
+    #  name: my-init-container
+
+  # -- Extra volumes, these can be later mounted on the extraInitContainers or to the Elasticsearch container.
+  extraVolumes: []
+    #- name: foo
+    #  configMap:
+    #    name: myconfigmap
+
+  # -- Extra volume to mount to the Elasticsearch container. Those must be first specified in the extraVolumes field.
+  extraVolumeMounts: []
+    #- name: foo
+    #  mountPath: "/etc/foo"
+    #  readOnly: true
 
 index:
   # -- Enabling or disabling index nodes
@@ -557,6 +604,29 @@ index:
 
   affinityOverride: {}
 
+  # -- Extra initContainers to be run after the ones needed by Elasticsearch
+  extraInitContainers: []
+    #- command:
+    #  - sh
+    #  - -c
+    #  - |
+    #    echo "Hello World"
+    #  image: busybox:1.31
+    #  imagePullPolicy: IfNotPresent
+    #  name: my-init-container
+
+  # -- Extra volumes, these can be later mounted on the extraInitContainers or to the Elasticsearch container.
+  extraVolumes: []
+    #- name: foo
+    #  configMap:
+    #    name: myconfigmap
+
+  # -- Extra volume to mount to the Elasticsearch container. Those must be first specified in the extraVolumes field.
+  extraVolumeMounts: []
+    #- name: foo
+    #  mountPath: "/etc/foo"
+    #  readOnly: true
+
 client:
   # -- Enabling or disabling client nodes
   enabled: true
@@ -722,3 +792,26 @@ client:
       #  - emptyDir
 
   affinityOverride: {}
+
+  # -- Extra initContainers to be run after the ones needed by Elasticsearch
+  extraInitContainers: []
+    #- command:
+    #  - sh
+    #  - -c
+    #  - |
+    #    echo "Hello World"
+    #  image: busybox:1.31
+    #  imagePullPolicy: IfNotPresent
+    #  name: my-init-container
+
+  # -- Extra volumes, these can be later mounted on the extraInitContainers or to the Elasticsearch container.
+  extraVolumes: []
+    #- name: foo
+    #  configMap:
+    #    name: myconfigmap
+
+  # -- Extra volume to mount to the Elasticsearch container. Those must be first specified in the extraVolumes field.
+  extraVolumeMounts: []
+    #- name: foo
+    #  mountPath: "/etc/foo"
+    #  readOnly: true


### PR DESCRIPTION
**Jira issues:**
- [OPS-7966]

## Motivation

- Sometimes is useful to mount extra volumes to the elasticsearch container, for example from a configmap or a secret, to authenticate against a third-party service, for example, mounting a GCP ServiceAccount to authenticate against GCS to store snapshots.
- Sometimes is useful to run some commands before the actual container gets started, for example to make some configurations that otherwise would require building a new image.

## Changes

- Add ability to pass `extraVolumes` and `extraVolumeMounts` from the values.
- Add ability to pass `extraInitContainers` from the values, that will run right after the ones hard-coded in the templates.


[OPS-7966]: https://searchbroker.atlassian.net/browse/OPS-7966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ