### PR TITLE
Set up resources of default Elasticsearch initContainers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,128 @@
 gomplate
 .vscode/
+
+# Created by https://www.toptal.com/developers/gitignore/api/macos,intellij+all
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos,intellij+all
+
+### Intellij+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij+all Patch ###
+# Ignore everything but code style settings and run configurations
+# that are supposed to be shared within teams.
+
+.idea/*
+
+!.idea/codeStyles
+!.idea/runConfigurations
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+# End of https://www.toptal.com/developers/gitignore/api/macos,intellij+all

--- a/charts/elasticsearch-umbrella/Chart.yaml
+++ b/charts/elasticsearch-umbrella/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.9
+version: 0.8.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -24,14 +24,14 @@ appVersion: 7.17.2
 # A list of the chart requirements 
 dependencies:
   - name: elasticsearch-statefulset
-    version: "0.8.9"
+    version: "0.8.10"
     alias: master
   - name: elasticsearch-statefulset
-    version: "0.8.9"
+    version: "0.8.10"
     alias: data
   - name: elasticsearch-statefulset
-    version: "0.8.9"
+    version: "0.8.10"
     alias: index
   - name: elasticsearch-deployment
-    version: "0.8.9"
+    version: "0.8.10"
     alias: client

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/Chart.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.9
+version: 0.8.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/templates/deployment.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/templates/deployment.yaml
@@ -144,6 +144,10 @@ spec:
           name: increase-vm-max-map
           securityContext:
             privileged: true
+          {{- with .Values.initContainersResources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         - command:
           - sysctl
           - -w
@@ -153,6 +157,10 @@ spec:
           name: increase-vm-dirty-ratio
           securityContext:
             privileged: true
+          {{- with .Values.initContainersResources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         - command:
           - sysctl
           - -w
@@ -162,6 +170,10 @@ spec:
           name: increase-vm-dirty-background-ratio
           securityContext:
             privileged: true
+          {{- with .Values.initContainersResources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         - command:
           - sh
           - -c
@@ -171,6 +183,10 @@ spec:
           name: increase-fd-ulimit
           securityContext:
             privileged: true
+          {{- with .Values.initContainersResources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         - command:
           - sh
           - -c
@@ -180,6 +196,10 @@ spec:
           name: increase-fd-unlimited
           securityContext:
             privileged: true
+          {{- with .Values.initContainersResources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- with .Values.extraInitContainers }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/values.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-deployment/values.yaml
@@ -218,3 +218,12 @@ extraVolumeMounts: []
   #- name: foo
   #  mountPath: "/etc/foo"
   #  readOnly: true
+
+# -- Set up resources of default Elasticsearch initContainers (same for all)
+initContainersResources: {}
+  #requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+  #limits:
+  #  cpu: 100m
+  #  memory: 128Mi

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/Chart.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.9
+version: 0.8.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/statefulset.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/templates/statefulset.yaml
@@ -195,7 +195,10 @@ spec:
           volumeMounts:
           - mountPath: /data
             name: data
-
+          {{- with .Values.initContainersResources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         - command:
           - sysctl
           - -w
@@ -205,6 +208,10 @@ spec:
           name: increase-vm-max-map
           securityContext:
             privileged: true
+          {{- with .Values.initContainersResources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         - command:
           - sysctl
           - -w
@@ -214,6 +221,10 @@ spec:
           name: increase-vm-dirty-ratio
           securityContext:
             privileged: true
+          {{- with .Values.initContainersResources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         - command:
           - sysctl
           - -w
@@ -223,6 +234,10 @@ spec:
           name: increase-vm-dirty-background-ratio
           securityContext:
             privileged: true
+          {{- with .Values.initContainersResources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         - command:
           - sh
           - -c
@@ -232,6 +247,10 @@ spec:
           name: increase-fd-ulimit
           securityContext:
             privileged: true
+          {{- with .Values.initContainersResources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         - command:
           - sh
           - -c
@@ -241,6 +260,10 @@ spec:
           name: increase-fd-unlimited
           securityContext:
             privileged: true
+          {{- with .Values.initContainersResources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- with .Values.extraInitContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/values.yaml
+++ b/charts/elasticsearch-umbrella/charts/elasticsearch-statefulset/values.yaml
@@ -238,3 +238,12 @@ extraVolumeMounts: []
   #- name: foo
   #  mountPath: "/etc/foo"
   #  readOnly: true
+
+# -- Set up resources of default Elasticsearch initContainers (same for all)
+initContainersResources: {}
+  #requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+  #limits:
+  #  cpu: 100m
+  #  memory: 128Mi

--- a/charts/elasticsearch-umbrella/values.yaml
+++ b/charts/elasticsearch-umbrella/values.yaml
@@ -216,6 +216,15 @@ master:
     #  mountPath: "/etc/foo"
     #  readOnly: true
 
+  # -- Set up resources of default Elasticsearch initContainers (same for all)
+  initContainersResources: {}
+    #requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+    #limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+
 data:
   # -- Enabling or disabling data nodes
   enabled: true
@@ -420,6 +429,15 @@ data:
     #- name: foo
     #  mountPath: "/etc/foo"
     #  readOnly: true
+
+  # -- Set up resources of default Elasticsearch initContainers (same for all)
+  initContainersResources: {}
+    #requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+    #limits:
+    #  cpu: 100m
+    #  memory: 128Mi
 
 index:
   # -- Enabling or disabling index nodes
@@ -626,6 +644,15 @@ index:
     #  mountPath: "/etc/foo"
     #  readOnly: true
 
+  # -- Set up resources of default Elasticsearch initContainers (same for all)
+  initContainersResources: {}
+    #requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+    #limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+
 client:
   # -- Enabling or disabling client nodes
   enabled: true
@@ -814,3 +841,12 @@ client:
     #- name: foo
     #  mountPath: "/etc/foo"
     #  readOnly: true
+
+  # -- Set up resources of default Elasticsearch initContainers (same for all)
+  initContainersResources: {}
+    #requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+    #limits:
+    #  cpu: 100m
+    #  memory: 128Mi


### PR DESCRIPTION
## Motivation

- Kroger is applying resource quotas on their k8s clusters and it's required that all containers (even initContainers) have implicitly configured resource requests and limits. 

## Changes

- Add ability to pass `initContainersResources` from the values to the default Elasticsearch initContainers.