### PR TITLE
Customize app path

### DIFF
--- a/charts/argocd-app-bootstrap/Chart.yaml
+++ b/charts/argocd-app-bootstrap/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0.0"
 description: Helm chart to automatically provision ArgoCD application and projects
 name: argocd-app-bootstrap
-version: 1.0.6
+version: 1.0.7

--- a/charts/argocd-app-bootstrap/templates/application.yaml
+++ b/charts/argocd-app-bootstrap/templates/application.yaml
@@ -22,17 +22,17 @@ spec:
     syncOptions:
     - CreateNamespace=true
   sources:
-    - repoURL: "{{$.Values.repoURL}}"
-      targetRevision: HEAD
+    - repoURL: "{{ $.Values.repoURL }}"
+      targetRevision: "{{ $.Values.targetRevision }}"
       ref: values
-    - repoURL: "{{$.Values.repoURL}}"
-      targetRevision: HEAD
-      path: applications/{{ $projectName }}/{{ $appName }}
+    - repoURL: "{{ $.Values.repoURL }}"
+      targetRevision: "{{ $.Values.targetRevision }}"
+      path: {{ $.Values.projectsRoot }}/applications/{{ $projectName }}/{{ $appName }}
       helm:
         valueFiles:
-          - $values/applications/{{ $projectName }}/{{ $appName }}/values.yaml
+          - $values/{{ $.Values.projectsRoot }}/applications/{{ $projectName }}/{{ $appName }}/values.yaml
         {{- range .extraValuesFiles }}
-          - $values/applications/{{ $projectName }}/{{ $appName }}/{{ . }}
+          - $values/{{ $.Values.projectsRoot }}/applications/{{ $projectName }}/{{ $appName }}/{{ . }}
         {{- end }}
   destination:
     server: https://kubernetes.default.svc

--- a/charts/argocd-app-bootstrap/values.yaml
+++ b/charts/argocd-app-bootstrap/values.yaml
@@ -1,4 +1,6 @@
 repoURL: ""
+targetRevision: "main"
+projectsRoot: "environments/test"
 
 global:
   metadata:


### PR DESCRIPTION
Allow chart users to provide a custom path where the `{{ project }}/{{ application }}` structure is placed within the repository.