### PR TITLE
OPS-8140 - Fix project name in project policy

### DIFF
--- a/charts/argocd-app-bootstrap/Chart.yaml
+++ b/charts/argocd-app-bootstrap/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0.0"
 description: Helm chart to automatically provision ArgoCD application and projects
 name: argocd-app-bootstrap
-version: 1.0.8
+version: 1.0.9

--- a/charts/argocd-app-bootstrap/Chart.yaml
+++ b/charts/argocd-app-bootstrap/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0.0"
 description: Helm chart to automatically provision ArgoCD application and projects
 name: argocd-app-bootstrap
-version: 1.0.9
+version: 1.0.10

--- a/charts/argocd-app-bootstrap/templates/application.yaml
+++ b/charts/argocd-app-bootstrap/templates/application.yaml
@@ -21,6 +21,12 @@ spec:
         project: {{ $projectName }}
     syncOptions:
     - CreateNamespace=true
+    retry:
+      limit: 6
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m0s
   sources:
     - repoURL: "{{ $.Values.repoURL }}"
       targetRevision: "{{ $.Values.targetRevision }}"

--- a/charts/argocd-app-bootstrap/templates/project.yaml
+++ b/charts/argocd-app-bootstrap/templates/project.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- toYaml (merge (default (dict) $projectSettings.labels) $.Values.global.metadata.labels) | nindent 4}}
 spec:
-{{ toYaml (default $.Values.global.projectSpec $projectSettings.projectSpec) | indent 2}}
+{{- toYaml (merge (default (dict) $projectSettings.projectSpec) $.Values.global.projectSpec) | nindent 2}}
   roles:
     - name: projectAdmin
       description: Admin privileges on the project

--- a/charts/argocd-app-bootstrap/templates/project.yaml
+++ b/charts/argocd-app-bootstrap/templates/project.yaml
@@ -12,13 +12,13 @@ spec:
     - name: projectAdmin
       description: Admin privileges on the project
       policies:
-        - p, proj:{{ .name }}:projectAdmin, applications, get, {{ $projectName }}/*, allow
-        - p, proj:{{ .name }}:projectAdmin, applications, create, {{ $projectName }}/*, allow
-        - p, proj:{{ .name }}:projectAdmin, applications, update, {{ $projectName }}/*, allow
-        - p, proj:{{ .name }}:projectAdmin, applications, delete, {{ $projectName }}/*, allow
-        - p, proj:{{ .name }}:projectAdmin, applications, sync, {{ $projectName }}/*, allow
-        - p, proj:{{ .name }}:projectAdmin, applications, override, {{ $projectName }}/*, allow
-        - p, proj:{{ .name }}:projectAdmin, applications, action/*, {{ $projectName }}/*, allow
+        - p, proj:{{ $projectName }}:projectAdmin, applications, get, {{ $projectName }}/*, allow
+        - p, proj:{{ $projectName }}:projectAdmin, applications, create, {{ $projectName }}/*, allow
+        - p, proj:{{ $projectName }}:projectAdmin, applications, update, {{ $projectName }}/*, allow
+        - p, proj:{{ $projectName }}:projectAdmin, applications, delete, {{ $projectName }}/*, allow
+        - p, proj:{{ $projectName }}:projectAdmin, applications, sync, {{ $projectName }}/*, allow
+        - p, proj:{{ $projectName }}:projectAdmin, applications, override, {{ $projectName }}/*, allow
+        - p, proj:{{ $projectName }}:projectAdmin, applications, action/*, {{ $projectName }}/*, allow
       groups:
         {{- with $projectSettings.adminGroups }}
           {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
**Jira issues:**
- [OPS-8140]

## Motivation

Projects are not granted with the correct permissions, as the project name is not getting rendered as part of the ApplicationProject manifest. This was caused as part of the chart update, as previously the name of the project was inside a `name` key, and now the project name is the key.

## Changes

- Fix project name in project policy.
- Bump chart version.

[OPS-8140]: https://searchbroker.atlassian.net/browse/OPS-8140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ