### PR TITLE
OPS-8328 - Customize namespace labels, toggle app rendering

### DIFF
--- a/charts/argocd-app-bootstrap/Chart.yaml
+++ b/charts/argocd-app-bootstrap/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0.0"
 description: Helm chart to automatically provision ArgoCD application and projects
 name: argocd-app-bootstrap
-version: 1.0.10
+version: 1.0.11

--- a/charts/argocd-app-bootstrap/templates/application.yaml
+++ b/charts/argocd-app-bootstrap/templates/application.yaml
@@ -1,6 +1,7 @@
 {{- range $projectName, $projectSettings := .Values.projects }}
 {{- range $projectSettings.applications }}
-{{- $appName := .name -}}
+{{ if (ne .enabled false) }}
+{{- $appName := .name }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -9,7 +10,7 @@ metadata:
   labels:
     {{- toYaml (merge (default (dict) .labels) (index $.Values.projects $projectName).labels) | nindent 4}}
 spec:
-  project: '{{ $projectName }}'
+  project: "{{ $projectName }}"
   syncPolicy:
     {{- if .autoSync.enabled }}
     automated:
@@ -18,7 +19,7 @@ spec:
     {{- end }}
     managedNamespaceMetadata:
       labels:
-        project: {{ $projectName }}
+        {{- toYaml (merge (default (dict) .labels) (index $.Values.projects $projectName).labels) | nindent 8}}
     syncOptions:
     - CreateNamespace=true
     retry:
@@ -48,5 +49,6 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/argocd-app-bootstrap/values.yaml
+++ b/charts/argocd-app-bootstrap/values.yaml
@@ -4,8 +4,7 @@ projectsRoot: "environments/test"
 
 global:
   metadata:
-    labels:
-      app.kubernetes.io/team: not-set
+    labels: {}
     namespace: argocd
   projectSpec:
     clusterResourceWhitelist: []
@@ -14,8 +13,7 @@ global:
 
 projects:
   global-project-settings:
-    labels:
-      app.kubernetes.io/team: not-set
+    labels: {}
     projectSpec:
       clusterResourceWhitelist: []
       destinations: []
@@ -26,7 +24,7 @@ projects:
 #      - admin@example.com
 #    applications:
 #      - name: app-name
-#        chart: chart-name
+#        enabled: true
 #        extraValuesFiles:
 #          - extra-values-file.yaml
 #        namespace: my-namespace


### PR DESCRIPTION
**Jira issues:**
- [OPS-8328]
- [OPS-8140]

## Motivation

Add the capability to grant per-namespace permissions based on namespace labels by customizing the labels set to namespaces automatically by ArgoCD.

Ability to enable/disable apps, to prevent them from being deployed on a given environment.

## Changes

- Propagate project labels to `managedNamespaceMetadata.labels`.
- Bump chart version.

[OPS-8328]: https://searchbroker.atlassian.net/browse/OPS-8328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OPS-8140]: https://searchbroker.atlassian.net/browse/OPS-8140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ