### PR TITLE
OPS-8140 - Render single-sourced Applications

### DIFF
--- a/charts/argocd-app-bootstrap/Chart.yaml
+++ b/charts/argocd-app-bootstrap/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0.0"
 description: Helm chart to automatically provision ArgoCD application and projects
 name: argocd-app-bootstrap
-version: 1.0.11
+version: 1.0.12

--- a/charts/argocd-app-bootstrap/templates/application.yaml
+++ b/charts/argocd-app-bootstrap/templates/application.yaml
@@ -28,19 +28,16 @@ spec:
         duration: 5s
         factor: 2
         maxDuration: 3m0s
-  sources:
-    - repoURL: "{{ $.Values.repoURL }}"
-      targetRevision: "{{ $.Values.targetRevision }}"
-      ref: values
-    - repoURL: "{{ $.Values.repoURL }}"
-      targetRevision: "{{ $.Values.targetRevision }}"
-      path: {{ $.Values.projectsRoot }}/applications/{{ $projectName }}/{{ $appName }}
-      helm:
-        valueFiles:
-          - $values/{{ $.Values.projectsRoot }}/applications/{{ $projectName }}/{{ $appName }}/values.yaml
-        {{- range .extraValuesFiles }}
-          - $values/{{ $.Values.projectsRoot }}/applications/{{ $projectName }}/{{ $appName }}/{{ . }}
-        {{- end }}
+  source:
+    repoURL: "{{ $.Values.repoURL }}"
+    targetRevision: "{{ $.Values.targetRevision }}"
+    path: {{ $.Values.projectsRoot }}/applications/{{ $projectName }}/{{ $appName }}
+    helm:
+      valueFiles:
+        - values.yaml
+      {{- range .extraValuesFiles }}
+        - {{ . }}
+      {{- end }}
   destination:
     server: https://kubernetes.default.svc
     namespace: {{ .namespace }}


### PR DESCRIPTION
**Jira issues:**
- [OPS-8140]

## Motivation

Multiple sourced Argo Applications caused the repo-server to miss the cache and to perform a huge amount of `git ls remote` requests, increasing the cost of the NAT GW.

## Changes

- Use single-source applications instead of multiple-source.
- Bump chart version.

[OPS-8140]: https://searchbroker.atlassian.net/browse/OPS-8140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ