### PR TITLE
OPS-10019 - Allow setting extraSyncOptions globally

### DIFF
--- a/charts/argocd-app-bootstrap/Chart.yaml
+++ b/charts/argocd-app-bootstrap/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0.0"
 description: Helm chart to automatically provision ArgoCD application and projects
 name: argocd-app-bootstrap
-version: 1.0.14
+version: 1.0.15

--- a/charts/argocd-app-bootstrap/templates/application.yaml
+++ b/charts/argocd-app-bootstrap/templates/application.yaml
@@ -25,9 +25,8 @@ spec:
       labels:
         {{- toYaml (merge (default (dict) .labels) (index $.Values.projects $projectName).labels) | nindent 8}}
     syncOptions:
-    - CreateNamespace=true
-    {{- with .extraSyncOptions }}
-    {{- toYaml . | nindent 4 }}
+    {{- range $syncOptionKey,$syncOptionValue := (merge (default (dict) .extraSyncOptions) $.Values.global.appSpec.extraSyncOptions) }}
+      - {{ $syncOptionKey }}={{ $syncOptionValue }}
     {{- end }}
     retry:
       limit: 6

--- a/charts/argocd-app-bootstrap/values.yaml
+++ b/charts/argocd-app-bootstrap/values.yaml
@@ -10,6 +10,10 @@ global:
     clusterResourceWhitelist: []
     destinations: []
     sourceRepos: []
+  appSpec:
+    extraSyncOptions: {}
+      #CreateNamespace: true
+      #ServerSideApply: true
 
 projects:
   global-project-settings:


### PR DESCRIPTION
**Jira issues:**
- [OPS-10019]

## Motivation

Allow setting mandatory syncOptions that are applicable to all Argo Applications, for example, setting `ServerSideApply=true` in all apps, as their resources may be mutated by some Kubernetes admission controller, like Kyverno.

## Changes

- Allow setting mandatory syncOptions globally, in a manner that can't be overwritten from application specific settings.

[OPS-10019]: https://searchbroker.atlassian.net/browse/OPS-10019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ